### PR TITLE
v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ## v0.7.4
-* Fixed rate-preserving NNLS merging, it can be considered more or less stable now
+* Fixed rate-preserving NNLS merging, it can be considered more or less stable now, but only for the 0D case,
+as preservation of spatial moments is not implemented
+* NNLS merging improvements (store original, non-scaled velocities and positions separately)
 * Improved test coverage
+* Slight re-ordering of `pretty_print_pia` output
 
 ## v0.7.3
 * Fixes in particle exchange for multi-threaded computations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v0.7.4
+* Fixed rate-preserving NNLS merging, it can be considered more or less stable now
+* Improved test coverage
 
 ## v0.7.3
 * Fixes in particle exchange for multi-threaded computations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ as preservation of spatial moments is not implemented
 * NNLS merging improvements (store original, non-scaled velocities and positions separately)
 * Improved test coverage
 * Slight re-ordering of `pretty_print_pia` output
+* `conservative` keyword added to `merge_roulette!` merging algorithm to ensure conservation of momentum and energy
 
 ## v0.7.3
 * Fixes in particle exchange for multi-threaded computations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+## v0.7.4
+
 ## v0.7.3
 * Fixes in particle exchange for multi-threaded computations
 * Python plotting script for 1-D flows now allows for multiple files + plot labels
-* `physical_props.jl', `surface_props.jl`, `flux_props.jl` files moved to new `src/properties` directory
+* `physical_props.jl`, `surface_props.jl`, `flux_props.jl` files moved to new `src/properties` directory
 * Added computation of mean collision frequency and mean free path for single-species VHS gases: `mean_free_path`,
 `mean_collision_frequency`
 * Speed-up of computation of `FluxProps` (unnecessary allocations removed)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Merzbild"
 uuid = "de01fcb4-c117-45a4-a951-7e39b0f12516"
 authors = ["Georgii Oblapenko <kunstmord@kunstmord.com>", "Leo Basov <basov.leo@gmail.com>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"

--- a/data/test_neutral_electron_data.xml
+++ b/data/test_neutral_electron_data.xml
@@ -7,6 +7,7 @@
         Synthetic data for testing</Source>
         <Reference>
         - Linear dependence of cross-section on energy, He.
+        - Constant cross-sections, Ar.
         </Reference>
     </References>
 
@@ -26,7 +27,7 @@
         Merzbild.jl reference
         </HowToReference>
         <MerzbildUrl>
-        https://git-ce.rwth-aachen.de/georgii.oblapenko/merzbild.jl
+        https://github.com/merzbild/Merzbild.jl
         </MerzbildUrl>
         
         <Groups>
@@ -94,6 +95,98 @@
                     
                     <DataY type="Cross section" units="m2" size="3">
                     0.000000e+0 1.0e-25 1.0e-24 
+                    </DataY>
+                    </Process>
+                </Processes>
+            </Group>
+        </Groups>
+    </Database>
+
+
+    <Database name="Constant elastic and ionizaton cross-sections, Ar" id="ConstantDB">
+        <Permlink>
+        knstmrd.github.io
+        </Permlink>
+        <Description>
+        These data are constant (sigma=1e-19 for elastic and cross-section, sigma=2.0e-20 for ionization cross-section).
+        </Description>
+
+        <Contact>
+        email georgii.oblapenko@fastmail.com
+        </Contact>
+
+        <HowToReference>
+        Merzbild.jl reference
+        </HowToReference>
+        <MerzbildUrl>
+        https://github.com/merzbild/Merzbild.jl
+        </MerzbildUrl>
+        
+        <Groups>
+            <Group id="Ar">
+                <Description>
+                Const E-sigma relationship</Description>
+                <Processes>
+                    <Process class="Scattering Cross Sections" type="Elastic">
+                        <Species>
+                            <Reactant>e</Reactant><Reactant>He</Reactant>
+                            <Product>E</Product><Product>He</Product>
+                        </Species>
+                        
+                        <Reaction>
+                        E + Ar -&gt; E + Ar
+                        </Reaction>
+                        
+                        <Parameters>
+                            <mM>
+                            1.37396e-5
+                            </mM>
+                            <Parameter>
+                            complete set
+                            </Parameter>
+                        </Parameters>
+                        <Comment>
+                        Constant, sigma = 1e-19
+                        </Comment>
+                        <DataX type="Energy" units="eV" size="4">
+                        0.000000e+0 1.0e2 5.0e2 1.0e3
+                        </DataX>
+                        <DataY type="Cross section" units="m2" size="4">
+                        1.0e-19 1.0e-19 1.0e-19 1.0e-19
+                        </DataY>
+                    </Process>
+
+                    <Process class="Scattering Cross Sections" type="Ionization">
+                    <Species>
+                        <Reactant>e</Reactant><Reactant>Ar</Reactant>
+                        <Product>E</Product><Product>E</Product><Product>Ar^+</Product>
+                    </Species>
+                    
+                    <Reaction>
+                    E + Ar -&gt; E + E + Ar^+
+                    </Reaction>
+                    
+                    <Parameters>
+                        <E units="eV">
+                        1.576e+1
+                        </E>
+                        <Parameter>
+                        complete set
+                        </Parameter>
+                    </Parameters>
+                    <Comment>
+                        Constant
+                    </Comment>
+                    <Updated>
+                    2024-10-17
+                    </Updated>
+                    
+                    <DataX type="Energy" units="eV" size="3">
+                    1.576e+1 3.0e+1 1.0e+2
+                    </DataX>
+                    
+                    <DataY type="Cross section" units="m2" size="3">
+                    0.000000e+0 2.0e-20 2.0e-20
                     </DataY>
                     </Process>
                 </Processes>

--- a/scripts/plot_1D.py
+++ b/scripts/plot_1D.py
@@ -2,6 +2,11 @@
 # python scripts/plot_1D.py --file scratch/data/couette_0.0005_50_500.0_300.0_1000.nc --propname T --startt 1
 # --plotname plots/couette_T.png --labels "Couette"
 # velocity is plotted with an offset of a linear profile that goes from -500 to 500 m/s
+# spartafile: optional path to SPARTA output file
+# spartavarid: number of the variable in the file to plot
+# it is assumed that the sparta cells are sorted, are the same ones as used in Merzbild.jl
+# the output should begin at line 10, line 9 is the header line
+# ITEM: CELLS id f_1[1] f_1[2] f_1[3] f_1[4] f_1[5] f_1[6] - to plot id set varid to 0, f_1[1] - set to 1, etc.
 
 from matplotlib import pyplot as plt
 import argparse
@@ -14,6 +19,8 @@ parser.add_argument("--propname", required=True)
 parser.add_argument("--plotname", required=True)
 parser.add_argument("--startt", required=True)
 parser.add_argument("--labels", nargs='+')
+parser.add_argument("--spartafile", required=False)
+parser.add_argument("--spartavarid", required=False)
 args = parser.parse_args()
 
 
@@ -68,6 +75,23 @@ for label, file in zip(labels, args.files):
 
     ds.close()
         
+if args.spartafile:
+    if not args.spartavarid:
+        print("No SPARTA variable number given!")
+    else:
+        varid = int(args.spartavarid)
+        sp_data = []
+        with open(args.spartafile) as f:
+            for i, line in enumerate(f):
+                if i>=9:
+                    lsp = line.split()
+                    sp_data.append(float(lsp[varid]))
+        if propname in ["ndens", "np", "T"]:
+            ax.plot(x_arr, sp_data, label=f"SPARTA, nt={i}", linewidth=2)
+        else:
+            voffset = np.linspace(-500, 500, nx)
+            ax.plot(x_arr, np.array(sp_data) - voffset, label=f"SPARTA, nt={i}", linewidth=2)
+
 ax.legend(fontsize=legend_size, ncol=2, framealpha=1.0)
 
 ax.grid()

--- a/src/collisions/collision_fp.jl
+++ b/src/collisions/collision_fp.jl
@@ -47,33 +47,33 @@ function fp_linear!(rng, collision_data_fp, interaction, species_data, particles
     sample_normal_rands!(rng, collision_data_fp, n_local)
     scale_norm_rands!(collision_data_fp, n_local)
 
-    for part_id in n_begin:n_end
-        @inbounds collision_data_fp.vel_ave = collision_data_fp.vel_ave + particles[part_id].v * particles[part_id].w
-        @inbounds local_w += particles[part_id].w
+    @inbounds for part_id in n_begin:n_end
+        collision_data_fp.vel_ave = collision_data_fp.vel_ave + particles[part_id].v * particles[part_id].w
+        local_w += particles[part_id].w
     end
 
     if indexer.n_group2 > 0
-        for part_id in indexer.start2:indexer.end2
-            @inbounds collision_data_fp.vel_ave = vel_ave + particles[part_id].v * particles[part_id].w
-            @inbounds local_w += particles[part_id].w
+        @inbounds for part_id in indexer.start2:indexer.end2
+            collision_data_fp.vel_ave = vel_ave + particles[part_id].v * particles[part_id].w
+            local_w += particles[part_id].w
         end
     end
 
     collision_data_fp.vel_ave = collision_data_fp.vel_ave / local_w
 
-    for part_id in n_begin:n_end
-        @inbounds particles[part_id].v = particles[part_id].v - collision_data_fp.vel_ave
-        @inbounds es_old = es_old + (particles[part_id].v[1]^2
-                                     + particles[part_id].v[2]^2
-                                     + particles[part_id].v[3]^2) * particles[part_id].w
+    @inbounds for part_id in n_begin:n_end
+        particles[part_id].v = particles[part_id].v - collision_data_fp.vel_ave
+        es_old = es_old + (particles[part_id].v[1]^2
+                           + particles[part_id].v[2]^2
+                           + particles[part_id].v[3]^2) * particles[part_id].w
     end
 
     if indexer.n_group2 > 0
-        for part_id in indexer.start2:indexer.end2
-            @inbounds particles[part_id].v = particles[part_id].v - collision_data_fp.vel_ave
-            @inbounds es_old = es_old + (particles[part_id].v[1]^2
-                                         + particles[part_id].v[2]^2
-                                         + particles[part_id].v[3]^2) * particles[part_id].w
+        @inbounds for part_id in indexer.start2:indexer.end2
+            particles[part_id].v = particles[part_id].v - collision_data_fp.vel_ave
+            es_old = es_old + (particles[part_id].v[1]^2
+                               + particles[part_id].v[2]^2
+                               + particles[part_id].v[3]^2) * particles[part_id].w
         end
     end
 
@@ -85,27 +85,27 @@ function fp_linear!(rng, collision_data_fp, interaction, species_data, particles
 
     C = sqrt(((2.0 / 3.0) * es_old + (Krot + Kvib) * τ) * (1.0 - exp(-2.0 * Δt/τ)))
 
-    for part_id in n_begin:n_end
+    @inbounds for part_id in n_begin:n_end
         i = part_id - n_begin + 1
 
-        @inbounds particles[part_id].v = particles[part_id].v*A + C*SVector{3,Float64}(collision_data_fp.xvel_rand[i],
+        particles[part_id].v = particles[part_id].v*A + C*SVector{3,Float64}(collision_data_fp.xvel_rand[i],
                                                                              collision_data_fp.yvel_rand[i],
                                                                              collision_data_fp.zvel_rand[i])
-        @inbounds es_new = es_new + (particles[part_id].v[1]^2
-                                     + particles[part_id].v[2]^2
-                                     + particles[part_id].v[3]^2) * particles[part_id].w
+        es_new = es_new + (particles[part_id].v[1]^2
+                           + particles[part_id].v[2]^2
+                           + particles[part_id].v[3]^2) * particles[part_id].w
     end
 
     if indexer.n_group2 > 0
-        for part_id in indexer.start2:indexer.end2
+        @inbounds for part_id in indexer.start2:indexer.end2
             i = part_id - n_begin + 1
 
-            @inbounds particles[part_id].v = particles[part_id].v*A + C*SVector{3,Float64}(collision_data_fp.xvel_rand[i],
+            particles[part_id].v = particles[part_id].v*A + C*SVector{3,Float64}(collision_data_fp.xvel_rand[i],
                                                                                  collision_data_fp.yvel_rand[i],
                                                                                  collision_data_fp.zvel_rand[i])
-            @inbounds es_new = es_new + (particles[part_id].v[1]^2
-                                      + particles[part_id].v[2]^2
-                                      + particles[part_id].v[3]^2) * particles[part_id].w
+            es_new = es_new + (particles[part_id].v[1]^2
+                               + particles[part_id].v[2]^2
+                               + particles[part_id].v[3]^2) * particles[part_id].w
         end
     end
 
@@ -113,13 +113,13 @@ function fp_linear!(rng, collision_data_fp, interaction, species_data, particles
 
     alpha = sqrt(es_old / es_new)
 
-    for part_id in n_begin:n_end
-        @inbounds particles[part_id].v = alpha*particles[part_id].v + collision_data_fp.vel_ave
+    @inbounds for part_id in n_begin:n_end
+        particles[part_id].v = alpha*particles[part_id].v + collision_data_fp.vel_ave
     end
 
     if indexer.n_group2 > 0
-        for part_id in indexer.start2:indexer.end2
-            @inbounds particles[part_id].v = alpha*particles[part_id].v + collision_data_fp.vel_ave
+        @inbounds for part_id in indexer.start2:indexer.end2
+            particles[part_id].v = alpha*particles[part_id].v + collision_data_fp.vel_ave
         end
     end
 end
@@ -162,10 +162,10 @@ and write them to a `CollisionDataFP` instance.
 * `n_local`: the number of particles to sample the numbers for
 """
 @inline function sample_normal_rands!(rng, collision_data_fp, n_local)
-    for i in 1:n_local
-        @inbounds collision_data_fp.xvel_rand[i] = randn(rng)
-        @inbounds collision_data_fp.yvel_rand[i] = randn(rng)
-        @inbounds collision_data_fp.zvel_rand[i] = randn(rng)
+    @inbounds for i in 1:n_local
+        collision_data_fp.xvel_rand[i] = randn(rng)
+        collision_data_fp.yvel_rand[i] = randn(rng)
+        collision_data_fp.zvel_rand[i] = randn(rng)
     end
 end
 
@@ -183,30 +183,30 @@ means for each component are exactly 0, and their variances are exactly 1.
     collision_data_fp.mean = SVector{3,Float64}(0.0, 0.0, 0.0)
     collision_data_fp.stddev = SVector{3,Float64}(0.0, 0.0, 0.0)
 
-    for i in 1:n_local
-        @inbounds collision_data_fp.mean = collision_data_fp.mean + SVector{3,Float64}(collision_data_fp.xvel_rand[i],
+    @inbounds for i in 1:n_local
+        collision_data_fp.mean = collision_data_fp.mean + SVector{3,Float64}(collision_data_fp.xvel_rand[i],
                                                                              collision_data_fp.yvel_rand[i],
                                                                              collision_data_fp.zvel_rand[i])
     end
 
     collision_data_fp.mean = collision_data_fp.mean / n_local
 
-    for i in 1:n_local
-        @inbounds collision_data_fp.xvel_rand[i] -= collision_data_fp.mean[1]
-        @inbounds collision_data_fp.yvel_rand[i] -= collision_data_fp.mean[2]
-        @inbounds collision_data_fp.zvel_rand[i] -= collision_data_fp.mean[3]
+    @inbounds for i in 1:n_local
+        collision_data_fp.xvel_rand[i] -= collision_data_fp.mean[1]
+        collision_data_fp.yvel_rand[i] -= collision_data_fp.mean[2]
+        collision_data_fp.zvel_rand[i] -= collision_data_fp.mean[3]
 
-        @inbounds collision_data_fp.stddev = collision_data_fp.stddev + SVector{3,Float64}(collision_data_fp.xvel_rand[i]^2,
+        collision_data_fp.stddev = collision_data_fp.stddev + SVector{3,Float64}(collision_data_fp.xvel_rand[i]^2,
                                                                                  collision_data_fp.yvel_rand[i]^2,
                                                                                  collision_data_fp.zvel_rand[i]^2)
     end
 
     collision_data_fp.stddev = SVector{3,Float64}(sqrt.(n_local ./ collision_data_fp.stddev))
 
-    for i in 1:n_local
-        @inbounds collision_data_fp.xvel_rand[i] *= collision_data_fp.stddev[1]
-        @inbounds collision_data_fp.yvel_rand[i] *= collision_data_fp.stddev[2]
-        @inbounds collision_data_fp.zvel_rand[i] *= collision_data_fp.stddev[3]
+    @inbounds for i in 1:n_local
+        collision_data_fp.xvel_rand[i] *= collision_data_fp.stddev[1]
+        collision_data_fp.yvel_rand[i] *= collision_data_fp.stddev[2]
+        collision_data_fp.zvel_rand[i] *= collision_data_fp.stddev[3]
     end
 end
 

--- a/src/merging/merging_nnls.jl
+++ b/src/merging/merging_nnls.jl
@@ -1022,16 +1022,19 @@ process ``p``.
 function scale_lhs_rhs_rate_preserving!(nnls_merging, lhs_matrix, ref_cs_elastic, ref_cs_ion, scaling, lhs_ncols)
     scale_lhs_rhs!(nnls_merging, lhs_matrix, scaling, lhs_ncols)
 
-    scaler_el = nnls_merging.inv_vref / ref_cs_elastic
-    scaler_ion = nnls_merging.inv_vref / ref_cs_ion
+    # scaler_el = nnls_merging.inv_vref / ref_cs_elastic
+    # scaler_ion = nnls_merging.inv_vref / ref_cs_ion
 
-    @inbounds for col in 1:lhs_ncols
-        lhs_matrix[nnls_merging.n_moments_vel+1, col] *= scaler_el
-        lhs_matrix[nnls_merging.n_moments_vel+2, col] *= scaler_ion
-    end
+    # scaler_el = 1.0 / (max(nnls_merging.rhs_vector[nnls_merging.n_moments_vel+1], 1e-30))
+    # scaler_ion = 1.0 / (max(nnls_merging.rhs_vector[nnls_merging.n_moments_vel+2], 1e-30))
 
-    @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+1] *= scaler_el
-    @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+2] *= scaler_ion
+    # @inbounds for col in 1:lhs_ncols
+    #     lhs_matrix[nnls_merging.n_moments_vel+1, col] *= scaler_el
+    #     lhs_matrix[nnls_merging.n_moments_vel+2, col] *= scaler_ion
+    # end
+
+    # @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+1] *= scaler_el
+    # @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+2] *= scaler_ion
 end
 
 """

--- a/src/merging/merging_nnls.jl
+++ b/src/merging/merging_nnls.jl
@@ -1277,7 +1277,7 @@ function merge_nnls_based!(rng, nnls_merging, particles, pia, cell, species;
     n_add = n_add + 8 * length(v_multipliers)
     @inbounds lhs_ncols = pia.indexer[cell, species].n_local + n_add + n_rand_pairs
 
-    if (lhs_ncols > nnls_merging.lhs_matrix_ncols_end) || (lhs_ncols < nnls_merging.lhs_matrix_ncols_start)
+    if (lhs_ncols > nnls_merging.lhs_matrix_ncols_end) || (lhs_ncols < nnls_merging.lhs_matrix_ncols_start) || length(nnls_merging.lhs_matrices) == 0
         indexer = nnls_merging.lhs_matrix_ncols_end - nnls_merging.lhs_matrix_ncols_start + 2
 
         # we either have pre-allocation [1,2,...[Workspace]]
@@ -1404,7 +1404,7 @@ function merge_nnls_based_rate_preserving!(rng, nnls_merging,
     n_add = n_add + 8 * length(v_multipliers)
     @inbounds lhs_ncols = pia.indexer[cell, species].n_local + n_add + n_rand_pairs
 
-    if (lhs_ncols > nnls_merging.lhs_matrix_ncols_end) || (lhs_ncols < nnls_merging.lhs_matrix_ncols_start)
+    if (lhs_ncols > nnls_merging.lhs_matrix_ncols_end) || (lhs_ncols < nnls_merging.lhs_matrix_ncols_start) || length(nnls_merging.lhs_matrices) == 0
         indexer = nnls_merging.lhs_matrix_ncols_end - nnls_merging.lhs_matrix_ncols_start + 2
 
         # we either have pre-allocation [1,2,...[Workspace]]

--- a/src/merging/merging_nnls.jl
+++ b/src/merging/merging_nnls.jl
@@ -44,6 +44,7 @@ Struct for keeping track of merging-related quantities for NNLS-based merging.
 * `lhs_matrix_ncols_start`: the number of columns in the first matrix in `lhs_matrices`
 * `lhs_matrix_ncols_end`: the number of columns in the last matrix in `lhs_matrices`
 * `column_norms`: vector of vectors of the column-wise inverse norms of the LHS matrices
+* `vel_pos_matrices`: vector of matrices of size `6xNp` that store the velocities and positions of the particles
 * `work`: Vector of `NNLSWorkspace` instances
 """
 mutable struct NNLSMerge
@@ -89,6 +90,7 @@ mutable struct NNLSMerge
     lhs_matrix_ncols_start::Int32
     lhs_matrix_ncols_end::Int32
     column_norms::Vector{Vector{Float64}}
+    vel_pos_matrices::Vector{Matrix{Float64}}
 
     # work::NNLSWorkspace #
     work::Vector{NNLSWorkspace}
@@ -167,6 +169,13 @@ mutable struct NNLSMerge
         else
             push!(nnls_ws_preallocated, NNLSWorkspace(zeros(n_total_conserved, init_np), zeros(n_total_conserved)))
         end
+
+        vel_pos_matrices = Vector{Matrix{Float64}}([])
+        if matrix_ncol_nprealloc > 0
+            for i in init_np:init_np+matrix_ncol_nprealloc
+                push!(vel_pos_matrices, zeros(6, i))
+            end
+        end
         
         return new(SVector{3,Float64}(0.0, 0.0, 0.0), SVector{3,Float64}(0.0, 0.0, 0.0),
                    1.0, 1.0, # vref, inv_vref
@@ -186,6 +195,7 @@ mutable struct NNLSMerge
                    pos_i_x, pos_i_y, pos_i_z,
                    matrices_preallocated, init_np, init_np+matrix_ncol_nprealloc,
                    column_norms,
+                   vel_pos_matrices,
                    nnls_ws_preallocated)
                 #    matrices_preallocated, init_np, init_np+matrix_ncol_nprealloc,
                 #    NNLSWorkspace(zeros(n_total_conserved, init_np), zeros(n_total_conserved)))
@@ -473,7 +483,7 @@ Computed unweighted central moment.
 end
 
 """
-    compute_lhs_and_rhs!(nnls_merging, lhs_matrix, particles, pia, cell, species)
+    compute_lhs_and_rhs!(nnls_merging, lhs_matrix, vel_pos_matrix, particles, pia, cell, species)
 
 Compute LHS matrix and RHS vector for NNLS merging. Returns the pre-merge number of particles.
 
@@ -481,6 +491,9 @@ Compute LHS matrix and RHS vector for NNLS merging. Returns the pre-merge number
 * `nnls_merging`: the `NNLSMerge` instance where the RHS vector will be stored
 * `lhs_matrix`: the matrix of size `n_total_conserved x n_particles`, where
     `n_total_conserved` is the number of conserved moments and `n_particles` is the pre-merge number of particles
+    + any fictitious particles
+* `vel_pos_matrix`: the matrix of size `6 x n_particles`, where `n_particles` is the pre-merge number of particles
+    + any fictitious particles, where their velocities and positions will be stored
 * `particles`: the `ParticleVector` instance containing the particles that are being merged
 * `pia`: the `ParticleIndexerArray` instance
 * `cell`: the index of the grid cell in which particles are being merged
@@ -489,7 +502,7 @@ Compute LHS matrix and RHS vector for NNLS merging. Returns the pre-merge number
 # Returns
 The pre-merge number of particles.
 """
-function compute_lhs_and_rhs!(nnls_merging, lhs_matrix,
+function compute_lhs_and_rhs!(nnls_merging, lhs_matrix, vel_pos_matrix,
                               particles, pia, cell, species)
     n_moms = nnls_merging.n_moments_vel
     
@@ -518,6 +531,13 @@ function compute_lhs_and_rhs!(nnls_merging, lhs_matrix,
         nnls_merging.Epy = nnls_merging.Epy + particles[i].w * (particles[i].x[2] - nnls_merging.x0[2])^2
         nnls_merging.Epz = nnls_merging.Epz + particles[i].w * (particles[i].x[3] - nnls_merging.x0[3])^2
 
+        vel_pos_matrix[1, col_index] = particles[i].v[1]
+        vel_pos_matrix[2, col_index] = particles[i].v[2]
+        vel_pos_matrix[3, col_index] = particles[i].v[3]
+        vel_pos_matrix[4, col_index] = particles[i].x[1]
+        vel_pos_matrix[5, col_index] = particles[i].x[2]
+        vel_pos_matrix[6, col_index] = particles[i].x[3]
+
         for n_mom in 1:n_moms
             tmp_ccm = ccm(particles[i].v, nnls_merging.v0, nnls_merging.mim[n_mom])
             nnls_merging.rhs_vector[n_mom] = nnls_merging.rhs_vector[n_mom] + particles[i].w * tmp_ccm
@@ -544,6 +564,14 @@ function compute_lhs_and_rhs!(nnls_merging, lhs_matrix,
             nnls_merging.Epx = nnls_merging.Epx + particles[i].w * (particles[i].x[1] - nnls_merging.x0[1])^2
             nnls_merging.Epy = nnls_merging.Epy + particles[i].w * (particles[i].x[2] - nnls_merging.x0[2])^2
             nnls_merging.Epz = nnls_merging.Epz + particles[i].w * (particles[i].x[3] - nnls_merging.x0[3])^2
+
+            vel_pos_matrix[1, col_index] = particles[i].v[1]
+            vel_pos_matrix[2, col_index] = particles[i].v[2]
+            vel_pos_matrix[3, col_index] = particles[i].v[3]
+            vel_pos_matrix[4, col_index] = particles[i].x[1]
+            vel_pos_matrix[5, col_index] = particles[i].x[2]
+            vel_pos_matrix[6, col_index] = particles[i].x[3]
+
             # w_total += particles[i].w
             for n_mom in 1:nnls_merging.n_moments_vel
                 tmp_ccm = ccm(particles[i].v, nnls_merging.v0, nnls_merging.mim[n_mom])
@@ -581,7 +609,7 @@ function compute_lhs_and_rhs!(nnls_merging, lhs_matrix,
 end
 
 """
-    compute_lhs_and_rhs_rate_preserving!(nnls_merging, lhs_matrix, particles, pia, cell, species, extend)
+    compute_lhs_and_rhs_rate_preserving!(nnls_merging, lhs_matrix, vel_pos_matrix, particles, pia, cell, species, extend)
 
 Compute LHS matrix and RHS vector for the rate-preserving NNLS merging (for electrons). Approximate
     elastic scattering and electron-impact ionization rates are conserved.
@@ -590,6 +618,9 @@ Compute LHS matrix and RHS vector for the rate-preserving NNLS merging (for elec
 * `nnls_merging`: the `NNLSMerge` instance where the RHS vector will be stored
 * `lhs_matrix`: the matrix of size `n_total_conserved x n_particles`, where
     `n_total_conserved` is the number of conserved moments and `n_particles` is the pre-merge number of particles
+    + any fictitious particles
+* `vel_pos_matrix`: the matrix of size `6 x n_particles`, where `n_particles` is the pre-merge number of particles
+    + any fictitious particles, where their velocities and positions will be stored
 * `interaction`: the `Interaction` instance describing the electron-neutral interaction being considered
 * `electron_neutral_interactions`:  the `ElectronNeutralInteractions` instance storing the tabulated cross-section
     data used to compute the rates
@@ -602,7 +633,7 @@ Compute LHS matrix and RHS vector for the rate-preserving NNLS merging (for elec
     collisions for which approximate rates are being preserved.
 * `extend`: enum of `CSExtend` type that sets how out-of-range energy values are treated when computing cross-sections
 """
-function compute_lhs_and_rhs_rate_preserving!(nnls_merging, lhs_matrix,
+function compute_lhs_and_rhs_rate_preserving!(nnls_merging, lhs_matrix, vel_pos_matrix,
                                               interaction, electron_neutral_interactions, computed_cs,
                                               particles, pia, cell, species, neutral_species_index, extend)
     n_moms = nnls_merging.n_moments_vel
@@ -624,6 +655,13 @@ function compute_lhs_and_rhs_rate_preserving!(nnls_merging, lhs_matrix,
         nnls_merging.Ex = nnls_merging.Ex + particles[i].w * (particles[i].v[1] - nnls_merging.v0[1])^2
         nnls_merging.Ey = nnls_merging.Ey + particles[i].w * (particles[i].v[2] - nnls_merging.v0[2])^2
         nnls_merging.Ez = nnls_merging.Ez + particles[i].w * (particles[i].v[3] - nnls_merging.v0[3])^2
+
+        vel_pos_matrix[1, col_index] = particles[i].v[1]
+        vel_pos_matrix[2, col_index] = particles[i].v[2]
+        vel_pos_matrix[3, col_index] = particles[i].v[3]
+        vel_pos_matrix[4, col_index] = particles[i].x[1]
+        vel_pos_matrix[5, col_index] = particles[i].x[2]
+        vel_pos_matrix[6, col_index] = particles[i].x[3]
 
         for n_mom in 1:n_moms
             tmp_ccm = ccm(particles[i].v, nnls_merging.v0, nnls_merging.mim[n_mom])
@@ -651,6 +689,14 @@ function compute_lhs_and_rhs_rate_preserving!(nnls_merging, lhs_matrix,
             nnls_merging.Ex = nnls_merging.Ex + particles[i].w * (particles[i].v[1] - nnls_merging.v0[1])^2
             nnls_merging.Ey = nnls_merging.Ey + particles[i].w * (particles[i].v[2] - nnls_merging.v0[2])^2
             nnls_merging.Ez = nnls_merging.Ez + particles[i].w * (particles[i].v[3] - nnls_merging.v0[3])^2
+
+            vel_pos_matrix[1, col_index] = particles[i].v[1]
+            vel_pos_matrix[2, col_index] = particles[i].v[2]
+            vel_pos_matrix[3, col_index] = particles[i].v[3]
+            vel_pos_matrix[4, col_index] = particles[i].x[1]
+            vel_pos_matrix[5, col_index] = particles[i].x[2]
+            vel_pos_matrix[6, col_index] = particles[i].x[3]
+
             # w_total += particles[i].w
             for n_mom in 1:nnls_merging.n_moments_vel
                 tmp_ccm = ccm(particles[i].v, nnls_merging.v0, nnls_merging.mim[n_mom])
@@ -686,7 +732,7 @@ function compute_lhs_and_rhs_rate_preserving!(nnls_merging, lhs_matrix,
 end
 
 """
-    compute_lhs_particles_additional!(rng, col_index, nnls_merging, lhs_matrix,
+    compute_lhs_particles_additional!(rng, col_index, nnls_merging, lhs_matrix, vel_pos_matrix,
                                       particles, pia, cell, species,
                                       n_rand_pairs, centered_at_mean, v_multipliers)
 
@@ -704,6 +750,9 @@ additional particles.
 * `nnls_merging`: the `NNLSMerge` instance where the RHS vector will be stored
 * `lhs_matrix`: the matrix of size `n_total_conserved x n_particles`, where
     `n_total_conserved` is the number of conserved moments and `n_particles` is the pre-merge number of particles
+    + any fictitious particles
+* `vel_pos_matrix`: the matrix of size `6 x n_particles`, where `n_particles` is the pre-merge number of particles
+    + any fictitious particles, where their velocities and positions will be stored
 * `particles`: the `ParticleVector` instance containing the particles that are being merged
 * `pia`: the `ParticleIndexerArray` instance
 * `cell`: the index of the grid cell in which particles are being merged
@@ -712,7 +761,7 @@ additional particles.
 * `centered_at_mean`: whether to add a particle centered at the mean velocity of the system of particles
 * `v_multipliers`: the multipliers for the velocity variances of the particles to add aditional particles to the system
 """
-function compute_lhs_particles_additional!(rng, col_index, nnls_merging, lhs_matrix,
+function compute_lhs_particles_additional!(rng, col_index, nnls_merging, lhs_matrix, vel_pos_matrix,
                                            particles, pia, cell, species,
                                            n_rand_pairs, centered_at_mean, v_multipliers)
     n_moms = nnls_merging.n_moments_vel
@@ -726,6 +775,14 @@ function compute_lhs_particles_additional!(rng, col_index, nnls_merging, lhs_mat
         @inbounds for n_mom in 1:nnls_merging.n_moments_pos
             lhs_matrix[n_moms + n_mom, col_index] = 0.0
         end
+
+        vel_pos_matrix[1, col_index] = nnls_merging.v0[1]
+        vel_pos_matrix[2, col_index] = nnls_merging.v0[2]
+        vel_pos_matrix[3, col_index] = nnls_merging.v0[3]
+        vel_pos_matrix[4, col_index] = nnls_merging.x0[1]
+        vel_pos_matrix[5, col_index] = nnls_merging.x0[2]
+        vel_pos_matrix[6, col_index] = nnls_merging.x0[3]
+        
         col_index += 1
     end
 
@@ -747,6 +804,14 @@ function compute_lhs_particles_additional!(rng, col_index, nnls_merging, lhs_mat
             @inbounds for n_mom in 1:nnls_merging.n_moments_pos
                 lhs_matrix[n_moms + n_mom, col_index] = 0.0
             end
+
+            vel_pos_matrix[1, col_index] = nnls_merging.v0[1] + vx
+            vel_pos_matrix[2, col_index] = nnls_merging.v0[2] + vy
+            vel_pos_matrix[3, col_index] = nnls_merging.v0[3] + vz
+            vel_pos_matrix[4, col_index] = nnls_merging.x0[1]
+            vel_pos_matrix[5, col_index] = nnls_merging.x0[2]
+            vel_pos_matrix[6, col_index] = nnls_merging.x0[3]
+
             col_index += 1
         end
     end
@@ -775,6 +840,13 @@ function compute_lhs_particles_additional!(rng, col_index, nnls_merging, lhs_mat
                                                    nnls_merging.x0[1], nnls_merging.x0[2], nnls_merging.x0[3],
                                                    nnls_merging.mim[n_mom])
             end
+
+            vel_pos_matrix[1, col_index] = vx
+            vel_pos_matrix[2, col_index] = vy
+            vel_pos_matrix[3, col_index] = vz
+            vel_pos_matrix[4, col_index] = x
+            vel_pos_matrix[5, col_index] = y
+            vel_pos_matrix[6, col_index] = z
         end
         col_index += 1
     end
@@ -801,6 +873,9 @@ additional particles.
 * `nnls_merging`: the `NNLSMerge` instance where the RHS vector will be stored
 * `lhs_matrix`: the matrix of size `n_total_conserved x n_particles`, where
     `n_total_conserved` is the number of conserved moments and `n_particles` is the pre-merge number of particles
+    + any fictitious particles
+* `vel_pos_matrix`: the matrix of size `6 x n_particles`, where `n_particles` is the pre-merge number of particles
+    + any fictitious particles, where their velocities and positions will be stored
 * `interaction`: the `Interaction` instance describing the electron-neutral interaction being considered
 * `electron_neutral_interactions`:  the `ElectronNeutralInteractions` instance storing the tabulated cross-section
     data used to compute the rates
@@ -817,6 +892,7 @@ additional particles.
 * `extend`: enum of `CSExtend` type that sets how out-of-range energy values are treated when computing cross-sections
 """
 function compute_lhs_particles_additional_rate_preserving!(rng, col_index, nnls_merging, lhs_matrix,
+                                           vel_pos_matrix,
                                            interaction, electron_neutral_interactions, computed_cs, 
                                            particles, pia, cell, species, neutral_species_index,
                                            n_rand_pairs, centered_at_mean, v_multipliers, extend)
@@ -832,6 +908,13 @@ function compute_lhs_particles_additional_rate_preserving!(rng, col_index, nnls_
         compute_cross_sections_only!(computed_cs, interaction, v0, electron_neutral_interactions, neutral_species_index, extend)
         @inbounds lhs_matrix[nnls_merging.n_moments_vel+1, col_index] = get_cs_elastic(electron_neutral_interactions, computed_cs, neutral_species_index) * v0
         @inbounds lhs_matrix[nnls_merging.n_moments_vel+2, col_index] = get_cs_ionization(electron_neutral_interactions, computed_cs, neutral_species_index) * v0
+
+        vel_pos_matrix[1, col_index] = nnls_merging.v0[1]
+        vel_pos_matrix[2, col_index] = nnls_merging.v0[2]
+        vel_pos_matrix[3, col_index] = nnls_merging.v0[3]
+        # vel_pos_matrix[4, col_index] = nnls_merging.x0[1]
+        # vel_pos_matrix[5, col_index] = nnls_merging.x0[2]
+        # vel_pos_matrix[6, col_index] = nnls_merging.x0[3]
 
         col_index += 1
     end
@@ -855,6 +938,10 @@ function compute_lhs_particles_additional_rate_preserving!(rng, col_index, nnls_
             compute_cross_sections_only!(computed_cs, interaction, g, electron_neutral_interactions, neutral_species_index, extend)
             @inbounds lhs_matrix[nnls_merging.n_moments_vel+1, col_index] = get_cs_elastic(electron_neutral_interactions, computed_cs, neutral_species_index) * g
             @inbounds lhs_matrix[nnls_merging.n_moments_vel+2, col_index] = get_cs_ionization(electron_neutral_interactions, computed_cs, neutral_species_index) * g
+
+            vel_pos_matrix[1, col_index] = nnls_merging.v0[1] + vx
+            vel_pos_matrix[2, col_index] = nnls_merging.v0[2] + vy
+            vel_pos_matrix[3, col_index] = nnls_merging.v0[3] + vz
 
             col_index += 1
         end
@@ -881,6 +968,10 @@ function compute_lhs_particles_additional_rate_preserving!(rng, col_index, nnls_
             compute_cross_sections_only!(computed_cs, interaction, g, electron_neutral_interactions, neutral_species_index, extend)
             @inbounds lhs_matrix[nnls_merging.n_moments_vel+1, col_index] = get_cs_elastic(electron_neutral_interactions, computed_cs, neutral_species_index) * g
             @inbounds lhs_matrix[nnls_merging.n_moments_vel+2, col_index] = get_cs_ionization(electron_neutral_interactions, computed_cs, neutral_species_index) * g
+
+            vel_pos_matrix[1, col_index] = vx
+            vel_pos_matrix[2, col_index] = vy
+            vel_pos_matrix[3, col_index] = vz
             
         end
         col_index += 1
@@ -1000,7 +1091,7 @@ function scale_lhs_rhs!(nnls_merging, lhs_matrix, scaling, lhs_ncols)
 end
 
 """
-    scale_lhs_rhs_rate_preserving!(nnls_merging, lhs_matrix, ref_cs_elastic, ref_cs_ion)
+    scale_lhs_rhs_rate_preserving!(nnls_merging, lhs_matrix, ref_k_elastic, ref_k_ion)
 
 Scale the LHS and RHS of the NNLS system for the rate-preserving electron merging
 using the reference velocity ``v_{ref}`` and
@@ -1008,38 +1099,34 @@ reference elastic scattering and ionization cross-sections. Each moment is scale
 by ``(1/v_{ref})^{n_{tot}}``, where ``n_{tot}`` is the total order of the moment (i.e. for
 a moment with multi-index `(i,j,k)` the total order is `i+j+k`).
 The entries in the LHS and RHS corresponding to the rates are scaled by
-``1/(v_{ref} * \\sigma_{p})``, where ``\\sigma_{p}`` is the cross-section of
-process ``p``. 
+`ref_k_elastic`, `ref_k_ion`. 
 
 # Positional arguments
 * `nnls_merging`: the `NNLSMerge` instance
 * `lhs_matrix`: the matrix of the LHS
-* `ref_cs_elastic`: the reference elastic scattering cross-section
-* `ref_cs_ion`: the reference ionization cross-section
+* `ref_k_elastic`: the reference elastic collision rate coefficient
+* `ref_k_ion`: the reference ionization rate coefficient
 * `scaling`: how to scale entries (`:vref` or `:variance`)
 * `lhs_ncols`: number of columns in the LHS matrix
 """
-function scale_lhs_rhs_rate_preserving!(nnls_merging, lhs_matrix, ref_cs_elastic, ref_cs_ion, scaling, lhs_ncols)
+function scale_lhs_rhs_rate_preserving!(nnls_merging, lhs_matrix, ref_k_elastic, ref_k_ion, scaling, lhs_ncols)
     scale_lhs_rhs!(nnls_merging, lhs_matrix, scaling, lhs_ncols)
 
-    # scaler_el = nnls_merging.inv_vref / ref_cs_elastic
-    # scaler_ion = nnls_merging.inv_vref / ref_cs_ion
+    scaler_el = 1.0/ref_k_elastic
+    scaler_ion = 1.0/ref_k_ion
 
-    # scaler_el = 1.0 / (max(nnls_merging.rhs_vector[nnls_merging.n_moments_vel+1], 1e-30))
-    # scaler_ion = 1.0 / (max(nnls_merging.rhs_vector[nnls_merging.n_moments_vel+2], 1e-30))
+    @inbounds for col in 1:lhs_ncols
+        lhs_matrix[nnls_merging.n_moments_vel+1, col] *= scaler_el
+        lhs_matrix[nnls_merging.n_moments_vel+2, col] *= scaler_ion
+    end
 
-    # @inbounds for col in 1:lhs_ncols
-    #     lhs_matrix[nnls_merging.n_moments_vel+1, col] *= scaler_el
-    #     lhs_matrix[nnls_merging.n_moments_vel+2, col] *= scaler_ion
-    # end
-
-    # @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+1] *= scaler_el
-    # @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+2] *= scaler_ion
+    @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+1] *= scaler_el
+    @inbounds nnls_merging.rhs_vector[nnls_merging.n_moments_vel+2] *= scaler_ion
 end
 
 """
-    compute_post_merge_particles_nnls!(lhs_ncols, lhs_matrix,
-                                            nnls_merging, particles, pia, cell, species)
+    compute_post_merge_particles_nnls!(lhs_ncols, lhs_matrix, vel_pos_matrix,
+                                       nnls_merging, particles, pia, cell, species)
 
 Compute post-merge particles based on the solution of the NNLS problem. This will replace
 the particles with the post-merge ones and delete any extraneous particles.
@@ -1052,14 +1139,16 @@ the particles with the post-merge ones and delete any extraneous particles.
 * `cell`: the index of the grid cell in which particles are being merged
 * `species`: the index of the species being merged
 * `lhs_ncols`: the number of columns in the LHS matrix
-* `lhs_matrix`: the LHS matrix of the NNLS system
+* `vel_pos_matrix`: the matrix of size `6 x n_particles`, where `n_particles` is the pre-merge number of particles
+    + any fictitious particles, where their velocities and positions will be stored
 * `max_err`: maximum allowed value of the residual of the NNLS system
 * `w_threshold`: the relative (w.r.t the total computational weight of the particles being merge) value of the computational weight below which particles are discarded
 * `work_index`: the index of the `NNLSWorkspace` used to solve the NNLS system
 * `column_norms`: the vector of the column-wise norms of the LHS matrix
 """
 function compute_post_merge_particles_nnls!(nnls_merging::NNLSMerge, x::Vector{Float64}, particles,
-                                            pia, cell, species, lhs_ncols, lhs_matrix,
+                                            pia, cell, species, lhs_ncols,
+                                            vel_pos_matrix,
                                             max_err, w_threshold, work_index, column_norms)
     @inbounds if nnls_merging.work[work_index].rnorm > max_err
         return -1
@@ -1099,15 +1188,16 @@ function compute_post_merge_particles_nnls!(nnls_merging::NNLSMerge, x::Vector{F
             i = map_cont_index(pia.indexer[cell,species], curr_particle_index)
             curr_particle_index += 1
             particles[i].w = x[j] * nnls_merging.w_total# * column_norms[j]
-            particles[i].v = SVector{3, Float64}(nnls_merging.v0[1] + lhs_matrix[2, j] * nnls_merging.scalevx,
-                                                 nnls_merging.v0[2] + lhs_matrix[3, j] * nnls_merging.scalevy,
-                                                 nnls_merging.v0[3] + lhs_matrix[4, j] * nnls_merging.scalevz)
+            particles[i].v = SVector{3, Float64}(vel_pos_matrix[1,j],
+                                                 vel_pos_matrix[2,j],
+                                                 vel_pos_matrix[3,j])
             
-            px = nnls_merging.pos_i_x > 0.0 ? lhs_matrix[nnls_merging.n_moments_vel + nnls_merging.pos_i_x, j] * nnls_merging.scalex : 0.0
-            py = nnls_merging.pos_i_y > 0.0 ? lhs_matrix[nnls_merging.n_moments_vel + nnls_merging.pos_i_y, j] * nnls_merging.scaley : 0.0
-            pz = nnls_merging.pos_i_z > 0.0 ? lhs_matrix[nnls_merging.n_moments_vel + nnls_merging.pos_i_z, j] * nnls_merging.scalez : 0.0
+            # write positions or mean position if not specified as conserved momentt
+            px = nnls_merging.pos_i_x > 0.0 ? vel_pos_matrix[4,j] : nnls_merging.x0[1]
+            py = nnls_merging.pos_i_y > 0.0 ? vel_pos_matrix[5,j] : nnls_merging.x0[2]
+            pz = nnls_merging.pos_i_z > 0.0 ? vel_pos_matrix[6,j] : nnls_merging.x0[3]
 
-            particles[i].x = SVector{3,Float64}(nnls_merging.x0[1] + px, nnls_merging.x0[2] + py, nnls_merging.x0[3] + pz)
+            particles[i].x = SVector{3,Float64}(px, py, pz)
         end
     end
 
@@ -1199,6 +1289,7 @@ function merge_nnls_based!(rng, nnls_merging, particles, pia, cell, species;
          
         nnls_merging.work[indexer].QA = zeros(nnls_merging.n_total_conserved, lhs_ncols)
         lhs_matrix = zeros(nnls_merging.n_total_conserved, lhs_ncols)
+        vel_pos_matrix = zeros(6, lhs_ncols)
         resize!(nnls_merging.work[indexer].x, lhs_ncols)
         resize!(nnls_merging.work[indexer].w, lhs_ncols)
         resize!(nnls_merging.work[indexer].idx, lhs_ncols)
@@ -1206,29 +1297,31 @@ function merge_nnls_based!(rng, nnls_merging, particles, pia, cell, species;
     else
         indexer = lhs_ncols - nnls_merging.lhs_matrix_ncols_start + 1
         lhs_matrix = nnls_merging.lhs_matrices[lhs_ncols - nnls_merging.lhs_matrix_ncols_start + 1]
+        vel_pos_matrix = nnls_merging.vel_pos_matrices[lhs_ncols - nnls_merging.lhs_matrix_ncols_start + 1]
         column_norms = nnls_merging.column_norms[indexer]
     end
     nnls_merging.vref = vref
     nnls_merging.inv_vref = 1.0 / vref
 
     # create LHS matrix and fill RHS vector using existing particles
-    col_index = compute_lhs_and_rhs!(nnls_merging, nnls_merging.work[indexer].QA, particles, pia, cell, species)
+    col_index = compute_lhs_and_rhs!(nnls_merging, nnls_merging.work[indexer].QA, 
+                                     vel_pos_matrix, particles, pia, cell, species)
     # and add more columns
     compute_lhs_particles_additional!(rng, col_index, nnls_merging, nnls_merging.work[indexer].QA,
+                                      vel_pos_matrix,
                                       particles, pia, cell, species, n_rand_pairs,
                                       centered_at_mean, v_multipliers)
 
 
     scale_lhs_rhs!(nnls_merging, nnls_merging.work[indexer].QA, scaling, lhs_ncols)
 
-    lhs_matrix .= nnls_merging.work[indexer].QA
-    
     scale_columns!(nnls_merging.work[indexer].QA, column_norms)
     
     nnls_merging.work[indexer].Qb .= nnls_merging.rhs_vector
     solve!(nnls_merging.work[indexer], iteration_mult * size(nnls_merging.work[indexer].QA, 2), 1e-14)
-    return compute_post_merge_particles_nnls!(nnls_merging, nnls_merging.work[indexer].x, particles, pia, cell, species, lhs_ncols, lhs_matrix,
-                                                             max_err, w_threshold, indexer, column_norms)
+    return compute_post_merge_particles_nnls!(nnls_merging, nnls_merging.work[indexer].x, particles, pia, cell, species,
+                                              lhs_ncols, vel_pos_matrix,
+                                              max_err, w_threshold, indexer, column_norms)
 end
 
 """
@@ -1271,11 +1364,11 @@ the NNLS matrix and RHS corresponding to conservation of electron-neutral collis
 * `species`: the index of the species being merged
 * `neutral_species_index`: the index of the neutral species which is the collision partner in the electron-neutral
     collisions for which approximate rates are being preserved.
-* `ref_cs_elatic`: the reference elastic scattering cross-section used to scale the rates
-* `ref_cs_ion`: the reference electron-impact ionization cross-section used to scale the rates
+* `ref_cs_elatic`: the reference elastic scattering cross-section used to scale the rates (currently not used)
+* `ref_cs_ion`: the reference electron-impact ionization cross-section used to scale the rates (currently not used)
 
 # Keyword arguments
-* `vref`: the reference velocity used to scale the velocities and the electron-neutral collision rates
+* `vref`: the reference velocity used to scale the velocities in the case of `scaling=:vref`
 * `scaling`: how to scale entries in the LHS and RHS of the NNLS system - either based on
     the reference velocity `vref` (`scaling=:vref`)
     or on the computed variances in each direction (`scaling=:variance`)
@@ -1323,6 +1416,7 @@ function merge_nnls_based_rate_preserving!(rng, nnls_merging,
 
         nnls_merging.work[indexer].QA = zeros(nnls_merging.n_total_conserved, lhs_ncols)
         lhs_matrix = zeros(nnls_merging.n_total_conserved, lhs_ncols)
+        vel_pos_matrix = zeros(6, lhs_ncols)
         resize!(nnls_merging.work[indexer].x, lhs_ncols)
         resize!(nnls_merging.work[indexer].w, lhs_ncols)
         resize!(nnls_merging.work[indexer].idx, lhs_ncols)
@@ -1330,6 +1424,7 @@ function merge_nnls_based_rate_preserving!(rng, nnls_merging,
     else
         indexer = lhs_ncols - nnls_merging.lhs_matrix_ncols_start + 1
         lhs_matrix = nnls_merging.lhs_matrices[lhs_ncols - nnls_merging.lhs_matrix_ncols_start + 1]
+        vel_pos_matrix = nnls_merging.vel_pos_matrices[lhs_ncols - nnls_merging.lhs_matrix_ncols_start + 1]
         column_norms = nnls_merging.column_norms[indexer]
     end
     nnls_merging.vref = vref
@@ -1337,24 +1432,25 @@ function merge_nnls_based_rate_preserving!(rng, nnls_merging,
 
     # create LHS matrix and fill RHS vector using existing particles
     @inbounds col_index = compute_lhs_and_rhs_rate_preserving!(nnls_merging, nnls_merging.work[indexer].QA,
+                                                     vel_pos_matrix,
                                                      interaction[species,neutral_species_index],
                                                      electron_neutral_interactions, computed_cs, 
                                                      particles, pia, cell, species, neutral_species_index, extend)
     # and add more columns
     @inbounds compute_lhs_particles_additional_rate_preserving!(rng, col_index, nnls_merging, nnls_merging.work[indexer].QA,
+                                                     vel_pos_matrix,
                                       interaction[species,neutral_species_index], electron_neutral_interactions, computed_cs,
                                       particles, pia, cell, species, neutral_species_index, n_rand_pairs,
                                       centered_at_mean, v_multipliers, extend)
 
-    scale_lhs_rhs_rate_preserving!(nnls_merging, nnls_merging.work[indexer].QA, ref_cs_elatic, ref_cs_ion, scaling, lhs_ncols)
-
-    lhs_matrix .= nnls_merging.work[indexer].QA
+    scale_lhs_rhs_rate_preserving!(nnls_merging, nnls_merging.work[indexer].QA, 1.0, 1.0, scaling, lhs_ncols)
 
     scale_columns!(nnls_merging.work[indexer].QA, column_norms)
 
     nnls_merging.work[indexer].Qb .= nnls_merging.rhs_vector
     solve!(nnls_merging.work[indexer], iteration_mult * size(nnls_merging.work[indexer].QA, 2), 1e-14)
-    return compute_post_merge_particles_nnls!(nnls_merging, nnls_merging.work[indexer].x, particles, pia, cell, species, lhs_ncols, lhs_matrix,
+    return compute_post_merge_particles_nnls!(nnls_merging, nnls_merging.work[indexer].x, particles, pia, cell, species,
+                                              lhs_ncols, vel_pos_matrix,
                                               max_err, w_threshold, indexer, column_norms)
 end
 end

--- a/src/merging/merging_nnls.jl
+++ b/src/merging/merging_nnls.jl
@@ -1344,9 +1344,10 @@ function merge_nnls_based_rate_preserving!(rng, nnls_merging,
                                       centered_at_mean, v_multipliers, extend)
 
     scale_lhs_rhs_rate_preserving!(nnls_merging, nnls_merging.work[indexer].QA, ref_cs_elatic, ref_cs_ion, scaling, lhs_ncols)
-    scale_columns!(nnls_merging.work[indexer].QA, column_norms)
 
     lhs_matrix .= nnls_merging.work[indexer].QA
+
+    scale_columns!(nnls_merging.work[indexer].QA, column_norms)
 
     nnls_merging.work[indexer].Qb .= nnls_merging.rhs_vector
     solve!(nnls_merging.work[indexer], iteration_mult * size(nnls_merging.work[indexer].QA, 2), 1e-14)

--- a/src/merging/merging_roulette.jl
+++ b/src/merging/merging_roulette.jl
@@ -28,7 +28,7 @@ function merge_roulette!(rng, particles, pia, cell, species, target_np; conserva
 
     # initial density, velocity, energy
     w_total0 = 0.0
-    v0 = SVector{3,Float64}([0.0, 0.0, 0.0])
+    v0 = SVector{3,Float64}(0.0, 0.0, 0.0)
     E0 = 0.0
     if conservative
         w_total0 = 0.0
@@ -128,7 +128,7 @@ function merge_roulette!(rng, particles, pia, cell, species, target_np; conserva
 
     # now we re-scale velocities if needed
     if conservative
-        v_mean_new = SVector{3,Float64}([0.0, 0.0, 0.0])
+        v_mean_new = SVector{3,Float64}(0.0, 0.0, 0.0)
         E_new = 0.0
 
         @inbounds s1 = pia.indexer[cell,species].start1

--- a/src/merging/merging_roulette.jl
+++ b/src/merging/merging_roulette.jl
@@ -12,15 +12,66 @@ to conserve number density.
 * `species`: the index of the species being merged
 * `target_np`: the target post-merge number of particles
 
+# Keyword arguments
+* `conservative`: if `true`, the post-merge particles' velocities will be corrected to ensure conservation of
+    momentum and energy
+
 # References
 * J. Watrous, D.B. Seidel, C.H. Moore, W. McDoniel,
     Improvements to Particle Merge Algorithms for Sandia National Laboratories Plasma Physics Modeling
     Code, EMPIRE. [Presentation, 2023](https://www.osti.gov/servlets/purl/2431184).
 """
-function merge_roulette!(rng, particles, pia, cell, species, target_np)
+function merge_roulette!(rng, particles, pia, cell, species, target_np; conservative=false)
     current_count = pia.indexer[cell, species].n_local
 
     n_to_delete = current_count - target_np
+
+    # initial density, velocity, energy
+    w_total0 = 0.0
+    v0 = SVector{3,Float64}([0.0, 0.0, 0.0])
+    E0 = 0.0
+    if conservative
+        w_total0 = 0.0
+
+        @inbounds s1 = pia.indexer[cell,species].start1
+        @inbounds e1 = pia.indexer[cell,species].end1
+        @inbounds for i in s1:e1
+            w_total0 += particles[i].w
+            v0 += particles[i].w * particles[i].v
+        end
+
+        @inbounds if pia.indexer[cell, species].n_group2 > 0
+            @inbounds s2 = pia.indexer[cell,species].start2
+            @inbounds e2 = pia.indexer[cell,species].end2
+            @inbounds for i in s2:e2
+                w_total0 += particles[i].w
+                v0 += particles[i].w * particles[i].v
+            end
+        end
+
+        v0 /= w_total0
+
+        # energy compute 
+        @inbounds s1 = pia.indexer[cell,species].start1
+        @inbounds e1 = pia.indexer[cell,species].end1
+        @inbounds for i in s1:e1
+            E0 += particles[i].w * ((particles[i].v[1] - v0[1])^2
+                                    + (particles[i].v[2] - v0[2])^2
+                                    + (particles[i].v[3] - v0[3])^2)
+        end
+
+        @inbounds if pia.indexer[cell, species].n_group2 > 0
+            @inbounds s2 = pia.indexer[cell,species].start2
+            @inbounds e2 = pia.indexer[cell,species].end2
+            @inbounds for i in s2:e2
+                E0 += particles[i].w * ((particles[i].v[1] - v0[1])^2
+                                        + (particles[i].v[2] - v0[2])^2
+                                        + (particles[i].v[3] - v0[3])^2)
+            end
+        end
+
+        E0 /= w_total0
+    end
 
     w_deleted = 0.0
 
@@ -32,28 +83,35 @@ function merge_roulette!(rng, particles, pia, cell, species, target_np)
         delete_particle!(particles, pia, cell, species, i_delete)
     end
 
+    scale_factor = 1.0
+
     # we most likely break continuity
     # and checking that we only deleted from group2 in the last domain cell
     # is kind of too much work for this merge
     @inbounds pia.contiguous[species] = false
 
-    w_total = 0.0
-    @inbounds s1 = pia.indexer[cell,species].start1
-    @inbounds e1 = pia.indexer[cell,species].end1
-    @inbounds for i in s1:e1
-        w_total += particles[i].w
-    end
-
-    @inbounds if pia.indexer[cell, species].n_group2 > 0
-        @inbounds s2 = pia.indexer[cell,species].start2
-        @inbounds e2 = pia.indexer[cell,species].end2
-        @inbounds for i in s2:e2
-            w_total += particles[i].w
+    if conservative
+        scale_factor = w_total0 / (w_total0 - w_deleted)
+    else
+        # first need to compute the remaining weight of the particles
+        w_total_new = 0.0
+        @inbounds s1 = pia.indexer[cell,species].start1
+        @inbounds e1 = pia.indexer[cell,species].end1
+        @inbounds for i in s1:e1
+            w_total_new += particles[i].w
         end
+
+        @inbounds if pia.indexer[cell, species].n_group2 > 0
+            @inbounds s2 = pia.indexer[cell,species].start2
+            @inbounds e2 = pia.indexer[cell,species].end2
+            @inbounds for i in s2:e2
+                w_total_new += particles[i].w
+            end
+        end
+        scale_factor = (w_total_new + w_deleted) / w_total_new
     end
 
-    scale_factor = (w_total + w_deleted) / w_total
-
+    # re-scale weights
     @inbounds s1 = pia.indexer[cell,species].start1
     @inbounds e1 = pia.indexer[cell,species].end1
     @inbounds for i in s1:e1
@@ -65,6 +123,63 @@ function merge_roulette!(rng, particles, pia, cell, species, target_np)
         @inbounds e2 = pia.indexer[cell,species].end2
         @inbounds for i in s2:e2
             particles[i].w *= scale_factor
+        end
+    end
+
+    # now we re-scale velocities if needed
+    if conservative
+        v_mean_new = SVector{3,Float64}([0.0, 0.0, 0.0])
+        E_new = 0.0
+
+        @inbounds s1 = pia.indexer[cell,species].start1
+        @inbounds e1 = pia.indexer[cell,species].end1
+        @inbounds for i in s1:e1
+            v_mean_new += particles[i].w * particles[i].v
+        end
+
+        @inbounds if pia.indexer[cell, species].n_group2 > 0
+            @inbounds s2 = pia.indexer[cell,species].start2
+            @inbounds e2 = pia.indexer[cell,species].end2
+            @inbounds for i in s2:e2
+                v_mean_new += particles[i].w * particles[i].v
+            end
+        end
+        v_mean_new /= w_total0
+
+        @inbounds s1 = pia.indexer[cell,species].start1
+        @inbounds e1 = pia.indexer[cell,species].end1
+        @inbounds for i in s1:e1
+            E_new += particles[i].w * ((particles[i].v[1] - v_mean_new[1])^2
+                                       + (particles[i].v[2] - v_mean_new[2])^2
+                                       + (particles[i].v[3] - v_mean_new[3])^2)
+        end
+
+        @inbounds if pia.indexer[cell, species].n_group2 > 0
+            @inbounds s2 = pia.indexer[cell,species].start2
+            @inbounds e2 = pia.indexer[cell,species].end2
+            @inbounds for i in s2:e2
+                E_new += particles[i].w * ((particles[i].v[1] - v_mean_new[1])^2
+                                           + (particles[i].v[2] - v_mean_new[2])^2
+                                           + (particles[i].v[3] - v_mean_new[3])^2)
+            end
+        end
+
+        E_new /= w_total0
+
+        E_scale = sqrt(E0 / E_new)
+
+        @inbounds s1 = pia.indexer[cell,species].start1
+        @inbounds e1 = pia.indexer[cell,species].end1
+        @inbounds for i in s1:e1
+            particles[i].v = E_scale*(particles[i].v - v_mean_new) + v0
+        end
+
+        @inbounds if pia.indexer[cell, species].n_group2 > 0
+            @inbounds s2 = pia.indexer[cell,species].start2
+            @inbounds e2 = pia.indexer[cell,species].end2
+            @inbounds for i in s2:e2
+                particles[i].v = E_scale*(particles[i].v - v_mean_new) + v0
+            end
         end
     end
 end

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -746,13 +746,19 @@ function pretty_print_pia(pia, species)
     n_cells = size(pia.indexer)[1]
     println("Total: $(pia.n_total[species])")
     for cell in 1:n_cells
+        out_string = ""
         if pia.indexer[cell,species].n_group1 > 0
-            println("Cell $cell: [$(pia.indexer[cell,species].start1), $(pia.indexer[cell,species].end1)]")
+            out_string *= "Cell $cell: group1: [$(pia.indexer[cell,species].start1), $(pia.indexer[cell,species].end1)]"
         end
-    end
-    for cell in 1:n_cells
         if pia.indexer[cell,species].n_group2 > 0
-            println("Cell $cell: [$(pia.indexer[cell,species].start2), $(pia.indexer[cell,species].end2)]")
+            if pia.indexer[cell,species].n_group1 > 0
+                out_string *= " group2: [$(pia.indexer[cell,species].start2), $(pia.indexer[cell,species].end2)]"
+            else
+                out_string *= "Cell $cell: group2: [$(pia.indexer[cell,species].start2), $(pia.indexer[cell,species].end2)]"
+            end
+        end
+        if out_string != ""
+            println(out_string)
         end
     end
 end

--- a/test/data/external/ar.species
+++ b/test/data/external/ar.species
@@ -1,0 +1,14 @@
+# Species data
+
+# ID
+# Molwt (amu)
+# Molmass (kg)
+# Rotational dof
+# RotRel
+# Vibrational dof
+# VibRel
+# VibTemp (K)
+# species wt
+# charge
+
+Ar  40.00    6.63E-26  0    .0   0   .0    0.0    1.0      0.0

--- a/test/data/external/ar.vhs
+++ b/test/data/external/ar.vhs
@@ -1,0 +1,8 @@
+# VHS collision model parameters for each species
+
+# diameter (m)
+# omega
+# tref
+# alpha
+
+Ar   4.11e-10 0.81  273.15  1.0

--- a/test/data/external/in.Couette
+++ b/test/data/external/in.Couette
@@ -13,7 +13,7 @@ global		    fnum 5e14  # 4e11?
 global              surfmax 1000
 
 
-species		    ar_he.species Ar
+species		    ar.species Ar
 mixture		    armixambi Ar vstream 0 0 0 temp 273.0 nrho 5e22
 
 create_particles armixambi n 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,28 +9,28 @@ using StableRNGs
 using LinearAlgebra
 using ChunkSplitters
 
-# include("test_indexing.jl")  # first we test indexing routines
-# include("test_constants.jl")  # test constants
-# include("test_species_data.jl")  # test loading of species data
-# include("test_computes.jl")  # we test functions that compute physical properties
-# include("test_io.jl")  # we test various I/O routines
-# include("test_sampling.jl")  # then we test sampling functions
-# include("test_grid_sampling.jl")  # then we test grid sampling functions
-# include("test_collision_utils.jl")  # then we test some collision utilities
-# include("test_bkw.jl")  # then we test the BKW relaxation case against reference solutions
-# include("test_2species.jl")  # then we test 2-species elastic collisions
-# include("test_merging_grid_indexing.jl")  # then we test basic indexing in grid-based merging
-# include("test_merging_grid_merging.jl")  # then we test grid-based merging in 0D
-# include("test_merging_grid_buffer_sorting.jl")  # then we test that particles are freed correctly in NNLS-based merging
-# include("test_bkw_varweight_grid.jl")  # then we test variable-weight NTC collisions+grid-based merging in 0D (BKW relaxation)
-# include("test_octree_bounds_and_splitting.jl")  # then we test bin bounds and splitting in octree merging
-# include("test_octree_sorting.jl")  # then we test sorting in octree merging
-# include("test_octree_merging.jl")  # then we test computation of props and octree merging
-# include("test_octree_merging_buffer_sorting.jl")  # then we test that particles are freed correctly in octree merging
-# include("test_bkw_varweight_octree.jl")  # then we test variable-weight NTC collisions+octree merging in 0D (BKW relaxation)
-# include("test_2species_varweight_octree.jl")  # 2-species variable-weight elastic collisions and merging
-# include("test_nnls_utils.jl")  # test NNLS-based merging utils first
-# include("test_nnls_merging.jl")  # test NNLS-based merging
+include("test_indexing.jl")  # first we test indexing routines
+include("test_constants.jl")  # test constants
+include("test_species_data.jl")  # test loading of species data
+include("test_computes.jl")  # we test functions that compute physical properties
+include("test_io.jl")  # we test various I/O routines
+include("test_sampling.jl")  # then we test sampling functions
+include("test_grid_sampling.jl")  # then we test grid sampling functions
+include("test_collision_utils.jl")  # then we test some collision utilities
+include("test_bkw.jl")  # then we test the BKW relaxation case against reference solutions
+include("test_2species.jl")  # then we test 2-species elastic collisions
+include("test_merging_grid_indexing.jl")  # then we test basic indexing in grid-based merging
+include("test_merging_grid_merging.jl")  # then we test grid-based merging in 0D
+include("test_merging_grid_buffer_sorting.jl")  # then we test that particles are freed correctly in NNLS-based merging
+include("test_bkw_varweight_grid.jl")  # then we test variable-weight NTC collisions+grid-based merging in 0D (BKW relaxation)
+include("test_octree_bounds_and_splitting.jl")  # then we test bin bounds and splitting in octree merging
+include("test_octree_sorting.jl")  # then we test sorting in octree merging
+include("test_octree_merging.jl")  # then we test computation of props and octree merging
+include("test_octree_merging_buffer_sorting.jl")  # then we test that particles are freed correctly in octree merging
+include("test_bkw_varweight_octree.jl")  # then we test variable-weight NTC collisions+octree merging in 0D (BKW relaxation)
+include("test_2species_varweight_octree.jl")  # 2-species variable-weight elastic collisions and merging
+include("test_nnls_utils.jl")  # test NNLS-based merging utils first
+include("test_nnls_merging.jl")  # test NNLS-based merging
 include("test_nnls_merging_buffer_sorting.jl")  # then we test that particles are freed correctly in NNLS-based merging
 include("test_bkw_varweight_nnls.jl")  # test NNLS-based merging
 include("test_electron_neutral_data.jl")  # test loading of XML LXCat-like data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,31 +9,32 @@ using StableRNGs
 using LinearAlgebra
 using ChunkSplitters
 
-include("test_indexing.jl")  # first we test indexing routines
-include("test_constants.jl")  # test constants
-include("test_species_data.jl")  # test loading of species data
-include("test_computes.jl")  # we test functions that compute physical properties
-include("test_io.jl")  # we test various I/O routines
-include("test_sampling.jl")  # then we test sampling functions
-include("test_grid_sampling.jl")  # then we test grid sampling functions
-include("test_collision_utils.jl")  # then we test some collision utilities
-include("test_bkw.jl")  # then we test the BKW relaxation case against reference solutions
-include("test_2species.jl")  # then we test 2-species elastic collisions
-include("test_merging_grid_indexing.jl")  # then we test basic indexing in grid-based merging
-include("test_merging_grid_merging.jl")  # then we test grid-based merging in 0D
-include("test_merging_grid_buffer_sorting.jl")  # then we test that particles are freed correctly in NNLS-based merging
-include("test_bkw_varweight_grid.jl")  # then we test variable-weight NTC collisions+grid-based merging in 0D (BKW relaxation)
-include("test_octree_bounds_and_splitting.jl")  # then we test bin bounds and splitting in octree merging
-include("test_octree_sorting.jl")  # then we test sorting in octree merging
-include("test_octree_merging.jl")  # then we test computation of props and octree merging
-include("test_octree_merging_buffer_sorting.jl")  # then we test that particles are freed correctly in octree merging
-include("test_bkw_varweight_octree.jl")  # then we test variable-weight NTC collisions+octree merging in 0D (BKW relaxation)
-include("test_2species_varweight_octree.jl")  # 2-species variable-weight elastic collisions and merging
-include("test_nnls_utils.jl")  # test NNLS-based merging utils first
-include("test_nnls_merging.jl")  # test NNLS-based merging
+# include("test_indexing.jl")  # first we test indexing routines
+# include("test_constants.jl")  # test constants
+# include("test_species_data.jl")  # test loading of species data
+# include("test_computes.jl")  # we test functions that compute physical properties
+# include("test_io.jl")  # we test various I/O routines
+# include("test_sampling.jl")  # then we test sampling functions
+# include("test_grid_sampling.jl")  # then we test grid sampling functions
+# include("test_collision_utils.jl")  # then we test some collision utilities
+# include("test_bkw.jl")  # then we test the BKW relaxation case against reference solutions
+# include("test_2species.jl")  # then we test 2-species elastic collisions
+# include("test_merging_grid_indexing.jl")  # then we test basic indexing in grid-based merging
+# include("test_merging_grid_merging.jl")  # then we test grid-based merging in 0D
+# include("test_merging_grid_buffer_sorting.jl")  # then we test that particles are freed correctly in NNLS-based merging
+# include("test_bkw_varweight_grid.jl")  # then we test variable-weight NTC collisions+grid-based merging in 0D (BKW relaxation)
+# include("test_octree_bounds_and_splitting.jl")  # then we test bin bounds and splitting in octree merging
+# include("test_octree_sorting.jl")  # then we test sorting in octree merging
+# include("test_octree_merging.jl")  # then we test computation of props and octree merging
+# include("test_octree_merging_buffer_sorting.jl")  # then we test that particles are freed correctly in octree merging
+# include("test_bkw_varweight_octree.jl")  # then we test variable-weight NTC collisions+octree merging in 0D (BKW relaxation)
+# include("test_2species_varweight_octree.jl")  # 2-species variable-weight elastic collisions and merging
+# include("test_nnls_utils.jl")  # test NNLS-based merging utils first
+# include("test_nnls_merging.jl")  # test NNLS-based merging
 include("test_nnls_merging_buffer_sorting.jl")  # then we test that particles are freed correctly in NNLS-based merging
 include("test_bkw_varweight_nnls.jl")  # test NNLS-based merging
 include("test_electron_neutral_data.jl")  # test loading of XML LXCat-like data
+include("test_nnls_ratepreserving_merging.jl")  # test NNLS merging with rate preservation
 include("test_acceleration.jl")  # test acceleration of charge particles
 include("test_indexing_particlevector.jl")  # test particle vector and multi-cell indexing
 include("test_indexing_particlebuffer.jl")  # test buffer in ParticleVector

--- a/test/test_debugging_functions.jl
+++ b/test/test_debugging_functions.jl
@@ -1,4 +1,30 @@
 @testset "debugging functions" begin
+
+    function create_pia()
+        pia_ = ParticleIndexerArray(4, 1)
+
+        pia_.n_total[1] = 9
+
+        pia_.indexer[1,1].n_local = 5
+        pia_.indexer[1,1].n_group1 = 3
+        pia_.indexer[1,1].start1 = 1
+        pia_.indexer[1,1].end1 = 3
+        pia_.indexer[1,1].n_group2 = 2
+        pia_.indexer[1,1].start2 = 4
+        pia_.indexer[1,1].end2 = 5
+
+        pia_.indexer[3,1].n_local = 3
+        pia_.indexer[3,1].n_group2 = 3
+        pia_.indexer[3,1].start2 = 6
+        pia_.indexer[3,1].end2 = 8
+
+        pia_.indexer[4,1].n_local = 1
+        pia_.indexer[4,1].n_group1 = 1
+        pia_.indexer[4,1].start1 = 9
+        pia_.indexer[4,1].end1 = 9
+        return pia_
+    end
+
     particles = [ParticleVector(10)]
     for i in 1:8
         Merzbild.add_particle!(particles[1], i, i*1.0, [2.0, 2.0, 3.0], [11.0, 12.0, 14.0])
@@ -8,7 +34,7 @@
 
     pia.n_total[1] = 8
 
-    pia.indexer[1,1].n_group1 = 3
+    pia.indexer[1,1].n_group1 = 8
     pia.indexer[1,1].start1 = 1
     pia.indexer[1,1].end1 = 8
 
@@ -34,28 +60,27 @@
     particles[1].index[4] = 4
     @test check_unique_index(particles[1], pia, 1) == (true, 0)
 
-    # test pia debugging
-    pia = ParticleIndexerArray(4, 1)
+    
+    particles = [ParticleVector(10)]
+    for i in 1:8
+        Merzbild.add_particle!(particles[1], i, i*1.0, [2.0, 2.0, 3.0], [11.0, 12.0, 14.0])
+    end
+    pia = ParticleIndexerArray(1, 1)
 
-    pia.n_total[1] = 9
+    pia.n_total[1] = 8
 
-    pia.indexer[1,1].n_local = 5
-    pia.indexer[1,1].n_group1 = 3
+    pia.indexer[1,1].n_group1 = 4
     pia.indexer[1,1].start1 = 1
-    pia.indexer[1,1].end1 = 3
-    pia.indexer[1,1].n_group2 = 2
-    pia.indexer[1,1].start2 = 4
-    pia.indexer[1,1].end2 = 5
+    pia.indexer[1,1].end1 = 4
+    pia.indexer[1,1].n_group2 = 4
+    pia.indexer[1,1].start2 = 5
+    pia.indexer[1,1].end2 = 8
 
-    pia.indexer[3,1].n_local = 3
-    pia.indexer[3,1].n_group2 = 3
-    pia.indexer[3,1].start2 = 6
-    pia.indexer[3,1].end2 = 8
+    # should be OK
+    @test check_unique_index(particles[1], pia, 1) == (true, 0)
 
-    pia.indexer[4,1].n_local = 1
-    pia.indexer[4,1].n_group1 = 1
-    pia.indexer[4,1].start1 = 9
-    pia.indexer[4,1].end1 = 9
+    # test pia debugging
+    pia = create_pia()
 
     @test check_pia_is_correct(pia, 1) == (true, 0)
 
@@ -63,7 +88,6 @@
     pia.n_total[1] = 8
 
     @test check_pia_is_correct(pia, 1) == (false, 0)
-
 
     # incorrect start of empty group
     pia.n_total[1] = 9
@@ -80,4 +104,37 @@
     # incorrect n_local
     pia.indexer[1,1].n_local = 6
     @test check_pia_is_correct(pia, 1) == (false, 1)
+
+    pia = create_pia()
+
+    # n_group1 = 0 but start1 != 0, end1 != -1
+    pia.indexer[3,1].start1 = 2
+    pia.indexer[3,1].end1 = 3
+    @test check_pia_is_correct(pia, 1) == (false, 3)
+
+    # n_group1 is not equal to e1 - s1 + 1
+    pia = create_pia()
+    pia.indexer[4,1].n_group2 = 2
+    @test check_pia_is_correct(pia, 1) == (false, 4)
+
+    # n_group2 is not equal to e2 - s2 + 1
+    pia = create_pia()
+    pia.indexer[3,1].n_group2 = 2
+    @test check_pia_is_correct(pia, 1) == (false, 3)
+
+    # test pretty_print_pia
+    pia = create_pia()
+
+    out = stdout
+    stream = redirect_stdout()
+    
+    pretty_print_pia(pia, 1)
+
+    redirect_stdout(out)
+    @test String(readavailable(stream)) == """
+    Total: 9
+    Cell 1: group1: [1, 3] group2: [4, 5]
+    Cell 3: group2: [6, 8]
+    Cell 4: group1: [9, 9]
+    """
 end

--- a/test/test_nnls_merging.jl
+++ b/test/test_nnls_merging.jl
@@ -553,4 +553,13 @@
     end
 
     @test abs(new_w - tw) < 4.5e-15
+
+
+    # finally test the edge case of init_np = total_np and no pre-allocated matrices, v_multipliers=[]
+    # reset particles
+    particles = [create_particles2(mult=2.0,mult2=2.0)]
+    pia = ParticleIndexerArray(length(particles[1]))
+
+    mnnls = NNLSMerge(add_vel_moments, length(particles[1]); multi_index_moments_pos=[])
+    merge_nnls_based!(rng, mnnls, particles[1], pia, 1, 1; centered_at_mean=false, n_rand_pairs=0, v_multipliers=[], w_threshold=1e-12)
 end

--- a/test/test_nnls_ratepreserving_merging.jl
+++ b/test/test_nnls_ratepreserving_merging.jl
@@ -133,9 +133,12 @@
 
     @test np_new < 24
 
+    k_rate_elastic = rate_elastic / w0
+    k_rate_ionization = rate_ionization / w0
+
     # test rate coefficients
-    @test abs(nnls_rp.rhs_vector[8] * w0 * vref * cs_ref - rate_elastic)/rate_elastic < 4*eps()
-    @test abs(nnls_rp.rhs_vector[9] * w0 * vref * cs_ref - rate_ionization)/rate_ionization < 4*eps()
+    @test abs(nnls_rp.rhs_vector[8] - k_rate_elastic)/k_rate_elastic < 4*eps()
+    @test abs(nnls_rp.rhs_vector[9] - k_rate_ionization)/k_rate_ionization < 4*eps()
 
     @test maximum(abs.(nnls.rhs_vector - nnls_rp.rhs_vector[1:7])) < 4*eps()
 

--- a/test/test_nnls_ratepreserving_merging.jl
+++ b/test/test_nnls_ratepreserving_merging.jl
@@ -149,7 +149,7 @@
     E_new = 0.5 * sum([particles[i].w * sum(particles[i].v.^2) for i in 1:np_new])/wnew
     @test abs(E_new - E0)/E0 < 1e-15
 
-    # finally test the edge case of 
+    # finally test the edge case of init_np = total_np and no pre-allocated matrices, v_multipliers=[]
     # reset particles
     particles, pia = create_particles(ndens)
 

--- a/test/test_nnls_ratepreserving_merging.jl
+++ b/test/test_nnls_ratepreserving_merging.jl
@@ -148,4 +148,21 @@
     # mean velocity is 0, so we can just sum up 0.5 v^2 and get energy (per unit mass)
     E_new = 0.5 * sum([particles[i].w * sum(particles[i].v.^2) for i in 1:np_new])/wnew
     @test abs(E_new - E0)/E0 < 1e-15
+
+    # finally test the edge case of 
+    # reset particles
+    particles, pia = create_particles(ndens)
+
+    nnls_rp = NNLSMerge(mim, 24; rate_preserving=true)
+
+    result = merge_nnls_based_rate_preserving!(rng, nnls_rp,
+                                               interaction_data, n_e_interactions, computed_cs,
+                                               particles, pia, 1, 1, 1,
+                                               cs_ref, cs_ref; scaling=:variance,
+                                               vref=vref, n_rand_pairs=0, max_err=1e-11,
+                                               centered_at_mean=false, v_multipliers=[], iteration_mult=2,
+                                               extend=CSExtendConstant)
+
+    @test result == 1
+    @test pia.n_total[1] < 24
 end

--- a/test/test_nnls_ratepreserving_merging.jl
+++ b/test/test_nnls_ratepreserving_merging.jl
@@ -1,0 +1,141 @@
+@testset "nnls rate-preserving merging" begin
+
+    function create_particles(weight_total)
+        pv = ParticleVector(24)
+
+        weight_per_particle = weight_total / 24
+
+        # create some electron particles
+        # E = 1/2 mv^2
+        # 15.76 eV = 2.525E-18 J
+        # v_ion = sqrt(2E/m)
+        # m = 9.11e-31
+        # v = 2.3545e6 m/s - any particle with v>this value will ionize
+        
+        ii = 1
+        for octant in 1:8
+            vx_s = Merzbild.vx_sign(octant)
+            vy_s = Merzbild.vy_sign(octant)
+            vz_s = Merzbild.vz_sign(octant)
+
+            pv[ii] = Particle(weight_per_particle, [vx_s * 1e3, vy_s * 1.2e3, vz_s * 0.9e3], [0.0, 0.0, 0.0])
+            Merzbild.update_particle_buffer_new_particle!(pv, ii)
+            ii += 1
+
+            pv[ii] = Particle(weight_per_particle, [vx_s * 3.2e5, vy_s * 0.9e4, vz_s * 4.5e5], [0.0, 0.0, 0.0])
+            Merzbild.update_particle_buffer_new_particle!(pv, ii)
+            ii += 1
+
+            pv[ii] = Particle(weight_per_particle, [vx_s * 2.5e6, vy_s * 1.2e3, vz_s * 1.5e4], [0.0, 0.0, 0.0])
+            Merzbild.update_particle_buffer_new_particle!(pv, ii)
+            ii += 1
+        end
+
+        pia_ = ParticleIndexerArray(24)
+
+        pia_.n_total[1] = 24
+        pia_.indexer[1,1].n_local = 24
+        pia_.indexer[1,1].n_group1 = 12
+        pia_.indexer[1,1].start1 = 1
+        pia_.indexer[1,1].end1 = 12
+        pia_.indexer[1,1].n_group2 = 12
+        pia_.indexer[1,1].start2 = 13
+        pia_.indexer[1,1].end2 = 24
+
+        return pv, pia_
+    end
+
+    seed = 1234
+    Random.seed!(seed)
+    rng = StableRNG(seed)
+
+    particles_data_path = joinpath(@__DIR__, "..", "data", "particles.toml")
+    species_data::Vector{Species} = load_species_data(particles_data_path, ["Ar", "e-"])
+
+    interaction_data_path = joinpath(@__DIR__, "..", "data", "vhs.toml")
+    interaction_data = load_interaction_data(interaction_data_path, species_data, 1e-10, 1.0, 273.0)
+
+    e_n_data_path = joinpath(@__DIR__, "..", "data", "test_neutral_electron_data.xml")
+    n_e_interactions = load_electron_neutral_interactions(species_data, e_n_data_path,
+                                                          Dict("Ar" => "ConstantDB"),
+                                                          Dict("Ar" => ScatteringIsotropic),
+                                                          Dict("Ar" => ElectronEnergySplitEqual))
+
+    computed_cs = create_computed_crosssections(n_e_interactions)
+
+    # conserve only the lowest-order moments
+    mim = [[0,0,0], [1,0,0], [0,1,0], [0,0,1], [2,0,0], [0,2,0], [0,0,2]]
+    nnls = NNLSMerge(mim, 20; rate_preserving=false)
+    nnls_rp = NNLSMerge(mim, 20; rate_preserving=true)
+
+    # 7 moments only
+    @test length(nnls.rhs_vector) == 7
+    @test size(nnls.work[1].QA) == (7,20)
+    @test length(nnls.work[1].Qb) == 7
+
+    # 7 moments + 2 rates
+    @test length(nnls_rp.rhs_vector) == 9
+    @test size(nnls_rp.work[1].QA) == (9,20)
+    @test length(nnls_rp.work[1].Qb) == 9
+
+    ndens = 1e15
+    particles, pia = create_particles(ndens)
+
+    w0 = sum([particles[i].w for i in 1:24])
+    @test abs(w0 - ndens)/ndens < 2*eps()
+
+    v0 = sum([particles[i].w * particles[i].v for i in 1:24])/w0
+    @test maximum(abs.(v0)) < 2*eps()
+
+    # mean velocity is 0, so we can just sum up 0.5 v^2 and get energy (per unit mass)
+    E0 = 0.5 * sum([particles[i].w * sum(particles[i].v.^2) for i in 1:24])/w0
+    
+    rate_elastic = 0.0
+    rate_ionization = 0.0
+
+    for i in 1:24
+        v_magnitude = norm(particles[i].v)
+        
+        Merzbild.compute_cross_sections!(computed_cs, interaction_data[1,2], v_magnitude,
+                                         n_e_interactions, 1; extend=CSExtendConstant)
+
+        cs_elastic = Merzbild.get_cs_elastic(n_e_interactions, computed_cs, 1)
+        @test abs(cs_elastic - 1e-19) / 1e-19 < 2 * eps()
+
+        rate_elastic += particles[i].w * cs_elastic * v_magnitude
+
+        rate_ionization += particles[i].w * Merzbild.get_cs_ionization(n_e_interactions, computed_cs, 1) * v_magnitude
+    end
+
+    @test rate_ionization > 0.0
+    # set some reference values
+    vref = 5e5
+    cs_ref = 1e-19
+
+    result = merge_nnls_based_rate_preserving!(rng, nnls_rp,
+                                               interaction_data, n_e_interactions, computed_cs,
+                                               particles, pia, 1, 1, 1,
+                                               cs_ref, cs_ref; scaling=:variance,
+                                               vref=vref, n_rand_pairs=0, max_err=1e-11,
+                                               centered_at_mean=false, v_multipliers=[], iteration_mult=2,
+                                               extend=CSExtendConstant)
+
+    @test result == 1
+    np_new = pia.n_total[1]
+
+    @test np_new < 24
+
+    # test rate coefficients
+    @test abs(nnls_rp.rhs_vector[8] * w0 * vref * cs_ref - rate_elastic)/rate_elastic < 4*eps()
+    @test abs(nnls_rp.rhs_vector[9] * w0 * vref * cs_ref - rate_ionization)/rate_ionization < 4*eps()
+
+    wnew = sum([particles[i].w for i in 1:np_new])
+    @test abs(wnew - w0)/w0 < 1e-14
+
+    v_new = sum([particles[i].w * particles[i].v for i in 1:np_new])/wnew
+    @test maximum(abs.(v0)) < 1e-14
+
+    # mean velocity is 0, so we can just sum up 0.5 v^2 and get energy (per unit mass)
+    E_new = 0.5 * sum([particles[i].w * sum(particles[i].v.^2) for i in 1:np_new])/wnew
+    @test abs(E_new - E0)/E0 < 1e-14
+end

--- a/test/test_nnls_ratepreserving_merging.jl
+++ b/test/test_nnls_ratepreserving_merging.jl
@@ -138,16 +138,14 @@
     @test abs(nnls_rp.rhs_vector[9] * w0 * vref * cs_ref - rate_ionization)/rate_ionization < 4*eps()
 
     @test maximum(abs.(nnls.rhs_vector - nnls_rp.rhs_vector[1:7])) < 4*eps()
-    println(nnls.rhs_vector)
-    println(nnls_rp.rhs_vector)
 
     wnew = sum([particles[i].w for i in 1:np_new])
-    @test abs(wnew - w0)/w0 < 1e-14
+    @test abs(wnew - w0)/w0 < 1e-15
 
     v_new = sum([particles[i].w * particles[i].v for i in 1:np_new])/wnew
     @test maximum(abs.(v0)) < 1e-14
 
     # mean velocity is 0, so we can just sum up 0.5 v^2 and get energy (per unit mass)
     E_new = 0.5 * sum([particles[i].w * sum(particles[i].v.^2) for i in 1:np_new])/wnew
-    @test abs(E_new - E0)/E0 < 1e-14
+    @test abs(E_new - E0)/E0 < 1e-15
 end

--- a/test/test_roulette_merging.jl
+++ b/test/test_roulette_merging.jl
@@ -183,29 +183,31 @@
     end
 
     # check that if we have post-merge particles in group2, the weight is still conserved
+    # and we also don't conserve momentum and energy
     vp = ParticleVector(12)
 
     x_cell1 = [0.05, 0.05, 0.05, 0.45]
     for i in 1:4
         Merzbild.update_particle_buffer_new_particle!(vp, i)
-        vp[i] = Particle(i, [0.5, 3.0, 4.0], [x_cell1[i], 0.0, 1.0])
+        vp[i] = Particle(i, [0.5 - 0.1*i, 3.0 + 2.0*i^2, 4.0-0.3*i], [x_cell1[i], 0.0, 1.0])
     end
 
     x_cell2 = [0.55, 0.95, 0.8, 0.85, 0.99]
     for i in 5:5
         Merzbild.update_particle_buffer_new_particle!(vp, i)
-        vp[i] = Particle(2.0, [-0.5, -3.0, -4.0], [x_cell2[i-4], 0.0, 2.0])
+        vp[i] = Particle(2.0, [-0.5+0.2*i^2, -3.0+(i*0.2)^3, -4.0+0.3*i], [x_cell2[i-4], 0.0, 2.0])
     end
 
     x_cell3 = [10.0, 11.0, 12.0]
     for i in 6:8
         Merzbild.update_particle_buffer_new_particle!(vp, i)
-        vp[i] = Particle(3.0, [20.0, 20.0, 20.0], [x_cell3[i-5], 0.0, 3.0])
+        vp[i] = Particle(3.0, [20.0-i, 20.0+0.5*i, 20.0-0.2*i], [x_cell3[i-5], 0.0, 3.0])
     end
 
+    # add more particles to cell2
     for i in 9:12
         Merzbild.update_particle_buffer_new_particle!(vp, i)
-        vp[i] = Particle(2.0, [-0.5, -3.0, -4.0], [x_cell2[i-7], 0.0, 2.0])
+        vp[i] = Particle(2.0, [-0.5-i, -3.0-0.05*i^2, -4.0+0.5*i], [x_cell2[i-7], 0.0, 2.0])
     end
 
     pia = ParticleIndexerArray(3, 1)
@@ -241,17 +243,183 @@
 
     pia.contiguous[1] = true
 
+    weight_per_cell = [0.0 for i in 1:3]
+    v0_per_cell = [zeros(3) for i in 1:3]
+    E_per_cell = [0.0 for i in 1:3]
+    for cell in 1:3
+        wt = 0.0
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            wt += vp[i].w
+            v0_per_cell[cell] += vp[i].w * vp[i].v
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            wt += vp[i].w
+            v0_per_cell[cell] += vp[i].w * vp[i].v
+        end
+        weight_per_cell[cell] = wt
+        v0_per_cell[cell] /= wt
+
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            E_per_cell[cell] += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            E_per_cell[cell] += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        E_per_cell[cell] /= wt
+    end
+
     merge_roulette!(rng, vp, pia, 2, 1, 3)
 
     @test pia.indexer[2,1].n_local == 3
     @test pia.indexer[2,1].n_group2 > 0
 
-    new_w = 0.0
-    for i in pia.indexer[2,1].start1:pia.indexer[2,1].end1
-        new_w += vp[i].w
+    for cell in 1:3
+        w_new = 0.0
+        v0_new = zeros(3)
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            w_new += vp[i].w
+            v0_new += vp[i].w * vp[i].v
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            w_new += vp[i].w
+            v0_new += vp[i].w * vp[i].v
+        end
+        v0_new /= w_new
+
+        E_new = 0.0
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            E_new += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            E_new += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        E_new /= w_new
+
+        @test abs(w_new - weight_per_cell[cell]) < 2*eps()
+        if cell == 2
+            @test maximum(abs.(v0_new - v0_per_cell[cell])) > 1e-10
+            @test abs(E_new - E_per_cell[cell]) > 1e-10
+        else
+            @test maximum(abs.(v0_new - v0_per_cell[cell])) < 2*eps()
+            @test abs(E_new - E_per_cell[cell]) < 2*eps()
+        end
     end
-    for i in pia.indexer[2,1].start2:pia.indexer[2,1].end2
-        new_w += vp[i].w
+
+    # similar test but now we have the conservative version
+    # and we also don't conserve momentum and energy
+    vp = ParticleVector(12)
+
+    x_cell1 = [0.05, 0.05, 0.05, 0.45]
+    for i in 1:4
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(i, [0.5 - 0.1*i, 3.0 + 2.0*i^2, 4.0-0.3*i], [x_cell1[i], 0.0, 1.0])
     end
-    @test abs(new_w - 10.0) < 2*eps()
+
+    x_cell2 = [0.55, 0.95, 0.8, 0.85, 0.99]
+    for i in 5:5
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(2.0, [-0.5+0.2*i^2, -3.0+(i*0.2)^3, -4.0+0.3*i], [x_cell2[i-4], 0.0, 2.0])
+    end
+
+    x_cell3 = [10.0, 11.0, 12.0]
+    for i in 6:8
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(3.0+0.5*i, [20.0-i, 20.0+0.5*i, 20.0-0.2*i], [x_cell3[i-5], 0.0, 3.0])
+    end
+
+    # add more particles to cell2
+    for i in 9:12
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(2.0+i, [-0.5-i, -3.0-0.05*i^2, -4.0+0.5*i], [x_cell2[i-7], 0.0, 2.0])
+    end
+
+    pia = ParticleIndexerArray(3, 1)
+
+    pia.n_total[1] = 12
+
+    pia.indexer[1,1].n_local = 4
+    pia.indexer[1,1].n_group1 = 4
+    pia.indexer[1,1].start1 = 1
+    pia.indexer[1,1].end1 = 4
+
+    pia.indexer[1,1].n_group2 = 0
+    pia.indexer[1,1].start2 = 0
+    pia.indexer[1,1].end2 = -1
+
+    pia.indexer[2,1].n_local = 5
+    pia.indexer[2,1].n_group1 = 1
+    pia.indexer[2,1].start1 = 5
+    pia.indexer[2,1].end1 = 5
+
+    pia.indexer[2,1].n_group2 = 4
+    pia.indexer[2,1].start2 = 9
+    pia.indexer[2,1].end2 = 12
+
+    pia.indexer[3,1].n_local = 3
+    pia.indexer[3,1].n_group1 = 3
+    pia.indexer[3,1].start1 = 6
+    pia.indexer[3,1].end1 = 8
+
+    pia.indexer[3,1].n_group2 = 0
+    pia.indexer[3,1].start2 = 0
+    pia.indexer[3,1].end2 = -1
+
+    pia.contiguous[1] = true
+
+    weight_per_cell = [0.0 for i in 1:3]
+    v0_per_cell = [zeros(3) for i in 1:3]
+    E_per_cell = [0.0 for i in 1:3]
+    for cell in 1:3
+        wt = 0.0
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            wt += vp[i].w
+            v0_per_cell[cell] += vp[i].w * vp[i].v
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            wt += vp[i].w
+            v0_per_cell[cell] += vp[i].w * vp[i].v
+        end
+        weight_per_cell[cell] = wt
+        v0_per_cell[cell] /= wt
+
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            E_per_cell[cell] += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            E_per_cell[cell] += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        E_per_cell[cell] /= wt
+    end
+
+    merge_roulette!(rng, vp, pia, 2, 1, 3; conservative=true)
+
+    @test pia.indexer[2,1].n_local == 3
+    @test pia.indexer[2,1].n_group2 > 0
+
+    for cell in 1:3
+        w_new = 0.0
+        v0_new = zeros(3)
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            w_new += vp[i].w
+            v0_new += vp[i].w * vp[i].v
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            w_new += vp[i].w
+            v0_new += vp[i].w * vp[i].v
+        end
+        v0_new /= w_new
+
+        E_new = 0.0
+        for i in pia.indexer[cell,1].start1:pia.indexer[cell,1].end1
+            E_new += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        for i in pia.indexer[cell,1].start2:pia.indexer[cell,1].end2
+            E_new += vp[i].w * sum((vp[i].v - v0_per_cell[cell]).^2)
+        end
+        E_new /= w_new
+
+        @test abs(w_new - weight_per_cell[cell]) < 2*eps()
+        @test maximum(abs.(v0_new - v0_per_cell[cell])) < 2e-15
+        @test abs(E_new - E_per_cell[cell]) < 2*eps()
+    end
 end

--- a/test/test_roulette_merging.jl
+++ b/test/test_roulette_merging.jl
@@ -181,4 +181,76 @@
         @test vp[i].x[1] in x_cell2
         @test vp[i].x[3] == 2.0
     end
+
+    vp = ParticleVector(12)
+
+    x_cell1 = [0.05, 0.05, 0.05, 0.45]
+    for i in 1:4
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(i, [0.5, 3.0, 4.0], [x_cell1[i], 0.0, 1.0])
+    end
+
+    x_cell2 = [0.55, 0.95, 0.8, 0.85, 0.99]
+    for i in 5:5
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(2.0, [-0.5, -3.0, -4.0], [x_cell2[i-4], 0.0, 2.0])
+    end
+
+    x_cell3 = [10.0, 11.0, 12.0]
+    for i in 6:8
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(3.0, [20.0, 20.0, 20.0], [x_cell3[i-5], 0.0, 3.0])
+    end
+
+    for i in 9:12
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = Particle(2.0, [-0.5, -3.0, -4.0], [x_cell2[i-7], 0.0, 2.0])
+    end
+
+    pia = ParticleIndexerArray(3, 1)
+
+    pia.n_total[1] = 12
+
+    pia.indexer[1,1].n_local = 4
+    pia.indexer[1,1].n_group1 = 4
+    pia.indexer[1,1].start1 = 1
+    pia.indexer[1,1].end1 = 4
+
+    pia.indexer[1,1].n_group2 = 0
+    pia.indexer[1,1].start2 = 0
+    pia.indexer[1,1].end2 = -1
+
+    pia.indexer[2,1].n_local = 5
+    pia.indexer[2,1].n_group1 = 1
+    pia.indexer[2,1].start1 = 5
+    pia.indexer[2,1].end1 = 5
+
+    pia.indexer[2,1].n_group2 = 4
+    pia.indexer[2,1].start2 = 9
+    pia.indexer[2,1].end2 = 12
+
+    pia.indexer[3,1].n_local = 3
+    pia.indexer[3,1].n_group1 = 3
+    pia.indexer[3,1].start1 = 6
+    pia.indexer[3,1].end1 = 8
+
+    pia.indexer[3,1].n_group2 = 0
+    pia.indexer[3,1].start2 = 0
+    pia.indexer[3,1].end2 = -1
+
+    pia.contiguous[1] = true
+
+    merge_roulette!(rng, vp, pia, 2, 1, 3)
+
+    @test pia.indexer[2,1].n_local == 3
+    @test pia.indexer[2,1].n_group2 > 0
+
+    new_w = 0.0
+    for i in pia.indexer[2,1].start1:pia.indexer[2,1].end1
+        new_w += vp[i].w
+    end
+    for i in pia.indexer[2,1].start2:pia.indexer[2,1].end2
+        new_w += vp[i].w
+    end
+    @test abs(new_w - 10.0) < 2*eps()
 end

--- a/test/test_roulette_merging.jl
+++ b/test/test_roulette_merging.jl
@@ -182,6 +182,7 @@
         @test vp[i].x[3] == 2.0
     end
 
+    # check that if we have post-merge particles in group2, the weight is still conserved
     vp = ParticleVector(12)
 
     x_cell1 = [0.05, 0.05, 0.05, 0.45]


### PR DESCRIPTION
* Fixed rate-preserving NNLS merging, it can be considered more or less stable now, but only for the 0D case,
as preservation of spatial moments is not implemented
* NNLS merging improvements (store original, non-scaled velocities and positions separately)
* Improved test coverage
* Slight re-ordering of `pretty_print_pia` output
* `conservative` keyword added to `merge_roulette!` merging algorithm to ensure conservation of momentum and energy