### PR TITLE
V0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Rate-preserving merging now makes use of reference process cross-sections
 * Fix in `simulations/OD/BKW/bkw.jl`
 * Clean-up of some `@inbounds` macros in sampling routines
+* Option to set merging grid extent explicitly when calling `merge_grid_based!`
+* Improved test coverage
 
 ## v0.7.5
 * Octree and grid-based merging can now handle bins/cells with only zero-weight particles inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.7.6
 * Speed-up of variable weight SWPM collisions
 * Rate-preserving merging now makes use of reference process cross-sections
+* Fix in `simulations/OD/BKW/bkw.jl`
 
 ## v0.7.5
 * Octree and grid-based merging can now handle bins/cells with only zero-weight particles inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Speed-up of variable weight SWPM collisions
 * Rate-preserving merging now makes use of reference process cross-sections
 * Fix in `simulations/OD/BKW/bkw.jl`
+* Clean-up of some `@inbounds` macros in sampling routines
 
 ## v0.7.5
 * Octree and grid-based merging can now handle bins/cells with only zero-weight particles inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.7.6
+* Speed-up of variable weight SWPM collisions
+
 ## v0.7.5
 * Octree and grid-based merging can now handle bins/cells with only zero-weight particles inside
 * Grid-based merging 1D version added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.7.6
 * Speed-up of variable weight SWPM collisions
+* Rate-preserving merging now makes use of reference process cross-sections
 
 ## v0.7.5
 * Octree and grid-based merging can now handle bins/cells with only zero-weight particles inside

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Merzbild"
 uuid = "de01fcb4-c117-45a4-a951-7e39b0f12516"
 authors = ["Georgii Oblapenko <kunstmord@kunstmord.com>", "Leo Basov <basov.leo@gmail.com>"]
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"

--- a/simulations/0D/BKW/bkw.jl
+++ b/simulations/0D/BKW/bkw.jl
@@ -58,7 +58,7 @@ function run(seed)
     particles::Vector{ParticleVector} = [ParticleVector(n_particles)]
     pia = ParticleIndexerArray(0)
 
-    sample_particles_equal_weight!(rng, particles[1], pia, 1, 1, n_particles, T0, species_data[1].mass, Fnum,
+    sample_particles_equal_weight!(rng, particles[1], pia, 1, 1, n_particles, species_data[1].mass, T0, Fnum,
                                    0.0, 1.0, 0.0, 1.0, 0.0, 1.0; distribution=:BKW)
 
     phys_props = PhysProps(1, 1, [4, 6, 8, 10], Tref=T0)

--- a/src/collisions/collision_swpm.jl
+++ b/src/collisions/collision_swpm.jl
@@ -272,9 +272,13 @@ function swpm!(rng, collision_factors_swpm, collision_data, interaction, particl
                 particles[k].w -= Δw
 
                 update_buffer_index_new_particle!(particles, pia, cell, species)
-                particles[pia.n_total[species]] = Particle(Δw, particles[i].v, particles[i].x)
+                particles[pia.n_total[species]].w = Δw
+                particles[pia.n_total[species]].v = particles[i].v
+                particles[pia.n_total[species]].x = particles[i].x
                 update_buffer_index_new_particle!(particles, pia, cell, species)
-                particles[pia.n_total[species]] = Particle(Δw, particles[k].v, particles[k].x)
+                particles[pia.n_total[species]].w = Δw
+                particles[pia.n_total[species]].v = particles[k].v
+                particles[pia.n_total[species]].x = particles[k].x
                 scatter_vhs!(rng, collision_data, interaction[species, species],
                              particles[pia.n_total[species]-1], particles[pia.n_total[species]])
             end

--- a/src/distributions_and_sampling.jl
+++ b/src/distributions_and_sampling.jl
@@ -207,8 +207,8 @@ function sample_bkw!(rng, particles, nparticles, offset, m, T, v0)
     vy = v_abs .* sintheta .* sin.(ϕ)
     vz = v_abs .* cos.(Θ)
 
-    for i in 1:nparticles
-        @inbounds particles[i+offset].v = vscale * SVector{3,Float64}(vx[i], vy[i], vz[i]) .+ v0
+    @inbounds for i in 1:nparticles
+        particles[i+offset].v = vscale * SVector{3,Float64}(vx[i], vy[i], vz[i]) .+ v0
     end
 end
 
@@ -252,12 +252,12 @@ the distribution has the prescribed computational weight/density.
 """
 function evaluate_distribution_on_grid!(vdf, distribution_function, grid, w_total, cutoff_v; normalize=true)
     w = 0.0
-    for k in 1:grid.base_grid.nz
+    @inbounds for k in 1:grid.base_grid.nz
         for j in 1:grid.base_grid.ny
             for i in 1:grid.base_grid.nx
-                @inbounds if (sqrt(grid.vx_grid[i]^2 + grid.vy_grid[j]^2 + grid.vz_grid[k]^2) <= cutoff_v)
-                    @inbounds vdf.w[i,j,k] = distribution_function(grid.vx_grid[i], grid.vy_grid[j], grid.vz_grid[k])
-                    @inbounds w += vdf.w[i,j,k]
+                if (sqrt(grid.vx_grid[i]^2 + grid.vy_grid[j]^2 + grid.vz_grid[k]^2) <= cutoff_v)
+                    vdf.w[i,j,k] = distribution_function(grid.vx_grid[i], grid.vy_grid[j], grid.vz_grid[k])
+                    w += vdf.w[i,j,k]
                 end
             end
         end
@@ -323,14 +323,14 @@ function sample_on_grid!(rng, vdf_func, particles, nv, m, T, n_total,
 
     pid = 0
     n_sampled = 0
-    for k in 1:v_grid.base_grid.nz
+    @inbounds for k in 1:v_grid.base_grid.nz
         for j in 1:v_grid.base_grid.ny
             for i in 1:v_grid.base_grid.nx
-                @inbounds if vdf.w[i,j,k] > 0.0
+                if vdf.w[i,j,k] > 0.0
                     pid += 1
                     n_sampled += 1
 
-                    @inbounds add_particle!(particles, pid, vdf.w[i,j,k],
+                    add_particle!(particles, pid, vdf.w[i,j,k],
                                   SVector{3}(v_grid.vx_grid[i] + noise * v_grid.dx * (0.5 - rand(rng, Float64)) + v_offset[1],
                                              v_grid.vy_grid[j] + noise * v_grid.dy * (0.5 - rand(rng, Float64)) + v_offset[2],
                                              v_grid.vz_grid[k] + noise * v_grid.dz * (0.5 - rand(rng, Float64)) + v_offset[3]),
@@ -432,13 +432,13 @@ Note: This does not update the particle weights, positions, or any indexing stru
 function sample_maxwellian!(rng, particles, nparticles, offset, m, T, v0)
     vscale = compute_thermal_velocity(m, T)
 
-    for i in 1:nparticles
+    @inbounds for i in 1:nparticles
         vn = sqrt(-log(rand(rng, Float64)))
         vr = sqrt(-log(rand(rng, Float64)))
         theta1 = twopi * rand(rng, Float64)
         theta2 = twopi * rand(rng, Float64)
 
-        @inbounds particles[i+offset].v = vscale * SVector{3,Float64}(vn * cos(theta1), vr * cos(theta2), vr * sin(theta2)) + v0
+        particles[i+offset].v = vscale * SVector{3,Float64}(vn * cos(theta1), vr * cos(theta2), vr * sin(theta2)) + v0
     end
 end
 
@@ -492,12 +492,12 @@ function sample_particles_equal_weight!(rng, particles, pia, cell, species,
 
     offset = start - 1
 
-    for i in 1:nparticles
+    @inbounds for i in 1:nparticles
         add_particle!(particles, i+offset, Fnum,  SVector{3}(0.0, 0.0, 0.0),
                       SVector{3}(xlo + rand(rng, Float64) * (xhi - xlo),
                                  ylo + rand(rng, Float64) * (yhi - ylo),
                                  zlo + rand(rng, Float64) * (zhi - zlo)))
-        @inbounds particles.cell[i+offset] = cell
+        particles.cell[i+offset] = cell
     end
 
     v0 = SVector{3}(vx0, vy0, vz0)

--- a/src/merging/merging_grid.jl
+++ b/src/merging/merging_grid.jl
@@ -176,7 +176,7 @@ in each velocity direction
 GridN2Merge(N::Int, extent_multiplier::Float64) = GridN2Merge(N, N, N, extent_multiplier)
 
 """
-    compute_velocity_extent!(merging_grid, cell, species, species_data, phys_props)
+    compute_velocity_extent!(merging_grid, cell, species, species_data, phys_props::PhysProps)
 
 Compute extent of velocity grid based on temperature in the cell.
 
@@ -187,12 +187,35 @@ Compute extent of velocity grid based on temperature in the cell.
 * `species_data`: the array of `Species` data
 * `phys_props`: the `PhysProps` instance containing the computed temperature
 """
-function compute_velocity_extent!(merging_grid, cell, species, species_data, phys_props)
+function compute_velocity_extent!(merging_grid, cell, species, species_data, phys_props::PhysProps)
     @inbounds dv = merging_grid.extent_multiplier .* sqrt.(2 * phys_props.T[cell, species] * k_B / species_data[species].mass)
     @inbounds merging_grid.extent_v_lower = phys_props.v[:, cell, species] .- dv
     @inbounds merging_grid.extent_v_upper = phys_props.v[:, cell, species] .+ dv
     @inbounds merging_grid.extent_v_mid = phys_props.v[:, cell, species]
     @inbounds merging_grid.Δv = SVector{3}(2 * dv[1] / merging_grid.Nx, 2 * dv[2] / merging_grid.Ny, 2 * dv[3] / merging_grid.Nz)
+    merging_grid.Δv_inv = 1.0 ./ merging_grid.Δv
+end
+
+"""
+    compute_velocity_extent!(merging_grid, vx_extent, vy_extent, vz_extent)
+
+Compute extent of velocity grid based on explicitly set extents.
+
+# Positional arguments:
+* `merging_grid`: the grid merging (`GridN2Merge`) instance for which to compute the extent
+* `vx_extent`: lower and upper bounds of the grid extent in the x velocity direction
+* `vy_extent`: lower and upper bounds of the grid extent in the y velocity direction
+* `vz_extent`: lower and upper bounds of the grid extent in the z velocity direction
+"""
+function compute_velocity_extent!(merging_grid, vx_extent, vy_extent, vz_extent)
+    @inbounds merging_grid.extent_v_lower = SVector(vx_extent[1], vy_extent[1], vz_extent[1])
+    @inbounds merging_grid.extent_v_upper = SVector(vx_extent[2], vy_extent[2], vz_extent[2])
+    @inbounds merging_grid.extent_v_mid = SVector(0.5 * (vx_extent[1] + vx_extent[2]),
+                                                  0.5 * (vy_extent[1] + vy_extent[2]),
+                                                  0.5 * (vz_extent[1] + vz_extent[2]))
+    @inbounds merging_grid.Δv = SVector{3}((vx_extent[2] - vx_extent[1]) / merging_grid.Nx,
+                                           (vy_extent[2] - vy_extent[1]) / merging_grid.Ny,
+                                           (vz_extent[2] - vz_extent[1]) / merging_grid.Nz)
     merging_grid.Δv_inv = 1.0 ./ merging_grid.Δv
 end
 
@@ -548,7 +571,7 @@ function compute_new_particles!(rng, merging_grid::GridN2Merge, particles, pia, 
 end
 
 """
-    merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props)
+    merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props::PhysProps)
 
 Merge particles using a velocity grid-based merging approach. A Cartesian grid in velocity
 space is used to group particles together (particles outside of the grid are group by velocity
@@ -571,7 +594,7 @@ in the physical grid cell being considered, as stored in the `phys_props` parame
     [Comput. Phys. Comm., 2015](https://doi.org/10.1016/j.cpc.2015.01.020).
 * G. Oblapenko, D. Goldstein, P. Varghese, C. Moore, A velocity space hybridization-based Boltzmann equation solver. [J. Comput. Phys, 2020](https://doi.org/10.1016/j.jcp.2020.109302).
 """
-function merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props)
+function merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props::PhysProps)
     # 0-D, no grid, particles in single cell
     compute_velocity_extent!(merging_grid, cell, species, species_data, phys_props)
     compute_grid!(merging_grid, particles, pia, cell, species)
@@ -580,7 +603,39 @@ end
 
 
 """
-    merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props, grid::Grid1DUniform)
+    merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, vx_extent, vy_extent, vz_extent)
+
+Merge particles using a velocity grid-based merging approach. A Cartesian grid in velocity
+space is used to group particles together (particles outside of the grid are group by velocity
+octant), and in each cell/octant, particles are merged down to 2 particles.
+The extent of the grid is specified explicitly.
+
+# Positional arguments:
+* `rng`: the random number generator instance
+* `merging_grid`: the grid merging (`GridN2Merge`) instance defining the velocity space grid
+* `particles`: the `ParticleVector` instance of the particles to be merged
+* `pia`: the `ParticleIndexerArray` instance
+* `cell`: the cell index
+* `species`: the species index
+* `species_data`: the array of `Species` data
+* `vx_extent`: lower and upper bounds of the grid extent in the x velocity direction
+* `vy_extent`: lower and upper bounds of the grid extent in the y velocity direction
+* `vz_extent`: lower and upper bounds of the grid extent in the z velocity direction
+
+# References
+* M. Vranic, T. Grismayer, J.L. Martins, R.A. Fonseca, L.O. Silva, Particle merging algorithm for PIC codes.
+    [Comput. Phys. Comm., 2015](https://doi.org/10.1016/j.cpc.2015.01.020).
+* G. Oblapenko, D. Goldstein, P. Varghese, C. Moore, A velocity space hybridization-based Boltzmann equation solver. [J. Comput. Phys, 2020](https://doi.org/10.1016/j.jcp.2020.109302).
+"""
+function merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, vx_extent, vy_extent, vz_extent)
+    # 0-D, no grid, particles in single cell
+    compute_velocity_extent!(merging_grid, vx_extent, vy_extent, vz_extent)
+    compute_grid!(merging_grid, particles, pia, cell, species)
+    compute_new_particles!(rng, merging_grid, particles, pia, cell, species)
+end
+
+"""
+    merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props::PhysProps, grid::Grid1DUniform)
 
 Merge particles using a velocity grid-based merging approach. A Cartesian grid in velocity
 space is used to group particles together (particles outside of the grid are group by velocity
@@ -605,9 +660,43 @@ If particle positions end up outside of the simulation domain, the particles are
     [Comput. Phys. Comm., 2015](https://doi.org/10.1016/j.cpc.2015.01.020).
 * G. Oblapenko, D. Goldstein, P. Varghese, C. Moore, A velocity space hybridization-based Boltzmann equation solver. [J. Comput. Phys, 2020](https://doi.org/10.1016/j.jcp.2020.109302).
 """
-function merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props, grid::Grid1DUniform)
+function merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, phys_props::PhysProps, grid::Grid1DUniform)
     # 0-D, no grid, particles in single cell
     compute_velocity_extent!(merging_grid, cell, species, species_data, phys_props)
+    compute_grid!(merging_grid, particles, pia, cell, species)
+    compute_new_particles!(rng, merging_grid, particles, pia, cell, species, grid)
+end
+
+"""
+    merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, vx_extent, vy_extent, vz_extent, grid::Grid1DUniform)
+
+Merge particles using a velocity grid-based merging approach. A Cartesian grid in velocity
+space is used to group particles together (particles outside of the grid are group by velocity
+octant), and in each cell/octant, particles are merged down to 2 particles.
+The extent of the grid is specified explicitly.
+If particle positions end up outside of the simulation domain, the particles are placed back into the domain.
+
+# Positional arguments:
+* `rng`: the random number generator instance
+* `merging_grid`: the grid merging (`GridN2Merge`) instance defining the velocity space grid
+* `particles`: the `ParticleVector` instance of the particles to be merged
+* `pia`: the `ParticleIndexerArray` instance
+* `cell`: the cell index
+* `species`: the species index
+* `species_data`: the array of `Species` data
+* `vx_extent`: lower and upper bounds of the grid extent in the x velocity direction
+* `vy_extent`: lower and upper bounds of the grid extent in the y velocity direction
+* `vz_extent`: lower and upper bounds of the grid extent in the z velocity direction
+* `grid`: the `Grid1DUniform` grid
+
+# References
+* M. Vranic, T. Grismayer, J.L. Martins, R.A. Fonseca, L.O. Silva, Particle merging algorithm for PIC codes.
+    [Comput. Phys. Comm., 2015](https://doi.org/10.1016/j.cpc.2015.01.020).
+* G. Oblapenko, D. Goldstein, P. Varghese, C. Moore, A velocity space hybridization-based Boltzmann equation solver. [J. Comput. Phys, 2020](https://doi.org/10.1016/j.jcp.2020.109302).
+"""
+function merge_grid_based!(rng, merging_grid, particles, pia, cell, species, species_data, vx_extent, vy_extent, vz_extent, grid::Grid1DUniform)
+    # 0-D, no grid, particles in single cell
+    compute_velocity_extent!(merging_grid, vx_extent, vy_extent, vz_extent)
     compute_grid!(merging_grid, particles, pia, cell, species)
     compute_new_particles!(rng, merging_grid, particles, pia, cell, species, grid)
 end

--- a/src/merging/merging_nnls.jl
+++ b/src/merging/merging_nnls.jl
@@ -1328,7 +1328,7 @@ end
     merge_nnls_based_rate_preserving!(rng, nnls_merging,
                                            interaction, electron_neutral_interactions, computed_cs,
                                            particles, pia, cell, species, neutral_species_index,
-                                           ref_cs_elatic, ref_cs_ion; scaling=:variance,
+                                           ref_cs_elastic, ref_cs_ion; scaling=:variance,
                                            vref=1.0, n_rand_pairs=0, max_err=1e-11,
                                            centered_at_mean=true, v_multipliers=[0.5, 1.0], iteration_mult=2,
                                            extend::CSExtend=CSExtendConstant)
@@ -1349,7 +1349,10 @@ the value of the multiplier times the velocity variance of that component (times
 or, if this value is outside of the bounding box, the closest bounding value of the velocity component in that direction
 is used instead and also multiplied by the variance multiplier.
 The reference velocity is also used in conjunction with the reference cross-sections to scale the parts of
-the NNLS matrix and RHS corresponding to conservation of electron-neutral collision rates.
+the NNLS matrix and RHS corresponding to conservation of electron-neutral collision rates. The reference rate is computed
+as ``\\sigma_{r,ref} v_{ref}``, where ``\\sigma_{r,ref}`` is the reference process cross-section. In case `scaling==:variance`,
+the reference velocity for the computation of reference rates is computed as ``v_{ref} = \\sqrt{E_x^2 + E_y^2 + E_z^2}``,
+where ``E_x``, ``E_y``, ``E_z`` are the variances of the velocity in the corresponding directions.
 
 # Positional arguments
 * `rng`: the random number generator instance
@@ -1364,8 +1367,8 @@ the NNLS matrix and RHS corresponding to conservation of electron-neutral collis
 * `species`: the index of the species being merged
 * `neutral_species_index`: the index of the neutral species which is the collision partner in the electron-neutral
     collisions for which approximate rates are being preserved.
-* `ref_cs_elatic`: the reference elastic scattering cross-section used to scale the rates (currently not used)
-* `ref_cs_ion`: the reference electron-impact ionization cross-section used to scale the rates (currently not used)
+* `ref_cs_elastic`: the reference elastic scattering cross-section used to scale the rates
+* `ref_cs_ion`: the reference electron-impact ionization cross-section used to scale the rates
 
 # Keyword arguments
 * `vref`: the reference velocity used to scale the velocities in the case of `scaling=:vref`
@@ -1394,7 +1397,7 @@ the number of non-zero (or smaller than `w_threshold`) elements in the solution 
 function merge_nnls_based_rate_preserving!(rng, nnls_merging,
                                            interaction, electron_neutral_interactions, computed_cs,
                                            particles, pia, cell, species, neutral_species_index,
-                                           ref_cs_elatic, ref_cs_ion; vref=1.0, scaling=:variance,
+                                           ref_cs_elastic, ref_cs_ion; vref=1.0, scaling=:variance,
                                            n_rand_pairs=0, max_err=1e-11,
                                            centered_at_mean=true, v_multipliers=[0.5, 1.0], iteration_mult=2, w_threshold=0.0,
                                            extend::CSExtend=CSExtendConstant)
@@ -1443,7 +1446,17 @@ function merge_nnls_based_rate_preserving!(rng, nnls_merging,
                                       particles, pia, cell, species, neutral_species_index, n_rand_pairs,
                                       centered_at_mean, v_multipliers, extend)
 
-    scale_lhs_rhs_rate_preserving!(nnls_merging, nnls_merging.work[indexer].QA, 1.0, 1.0, scaling, lhs_ncols)
+    
+    if scaling==:variance
+        vr_tmp = sqrt(nnls_merging.Ex^2 + nnls_merging.Ey^2 + nnls_merging.Ez^2)
+        ref_k_elastic = ref_cs_elastic * vr_tmp
+        ref_k_ion = ref_cs_ion * vr_tmp
+    else
+        ref_k_elastic = ref_cs_elastic * vref
+        ref_k_ion = ref_cs_ion * vref
+    end
+
+    scale_lhs_rhs_rate_preserving!(nnls_merging, nnls_merging.work[indexer].QA, ref_k_elastic, ref_k_ion, scaling, lhs_ncols)
 
     scale_columns!(nnls_merging.work[indexer].QA, column_norms)
 

--- a/test/test_merging_grid_merging.jl
+++ b/test/test_merging_grid_merging.jl
@@ -206,29 +206,45 @@
         @test particles24[1][i].w > 0
     end
 
-    gm = GridN2Merge(4, [0.5, 0.7, 0.9])
-    @test gm.Nx == 4
-    @test gm.Ny == 4
-    @test gm.Nz == 4
-    @test maximum(abs.(gm.extent_multiplier .- [0.5, 0.7, 0.9])) < 2 * eps()
+    mg = GridN2Merge(4, [0.5, 0.7, 0.9])
+    @test mg.Nx == 4
+    @test mg.Ny == 4
+    @test mg.Nz == 4
+    @test maximum(abs.(mg.extent_multiplier .- [0.5, 0.7, 0.9])) < 2 * eps()
 
-    gm = GridN2Merge(6, 1.5)
-    @test gm.Nx == 6
-    @test gm.Ny == 6
-    @test gm.Nz == 6
-    @test maximum(abs.(gm.extent_multiplier .- [1.5, 1.5, 1.5])) < 2 * eps()
+    mg = GridN2Merge(6, 1.5)
+    @test mg.Nx == 6
+    @test mg.Ny == 6
+    @test mg.Nz == 6
+    @test maximum(abs.(mg.extent_multiplier .- [1.5, 1.5, 1.5])) < 2 * eps()
 
-    gm = GridN2Merge(4, 6, 2, 3.0, 2.0, 1.0)
-    @test gm.Nx == 4
-    @test gm.Ny == 6
-    @test gm.Nz == 2
-    @test maximum(abs.(gm.extent_multiplier .- [3.0, 2.0, 1.0])) < 2 * eps()
-    # GridN2Merge(N::Int, extent_multiplier::T) where T <: AbstractArray = GridN2Merge(N, N, N, extent_multiplier)
-    # GridN2Merge(N::Int, extent_multiplier::Float64) = GridN2Merge(N, N, N, extent_multiplier)
-    # GridN2Merge(Nx::Int, Ny::Int, Nz::Int,
-    #         extent_multiplier_x::Float64,
-    #         extent_multiplier_y::Float64,
-    #         extent_multiplier_z::Float64) = GridN2Merge(Nx, Ny, Nz, [extent_multiplier_x,
-    #                                                                  extent_multiplier_y,
-    #                                                                  extent_multiplier_z])
+    mg = GridN2Merge(4, 6, 2, 3.0, 2.0, 1.0)
+    @test mg.Nx == 4
+    @test mg.Ny == 6
+    @test mg.Nz == 2
+    @test maximum(abs.(mg.extent_multiplier .- [3.0, 2.0, 1.0])) < 2 * eps()
+
+    particles24 = [create_24_3particles_in_octant(weights=weights_arr)]
+    compute_props!(particles24, pia, species_data, phys_props)
+    n0_computed = phys_props.n[1,1]
+    np0_computed = phys_props.np[1,1]
+    T0_computed = phys_props.T[1,1]
+    v0_computed = phys_props.v[:,1,1]
+
+    mg = GridN2Merge(4, 8, 2, 3.0, 2.0, 1.0)
+    merge_grid_based!(rng, mg, particles24[1], pia, 1, 1, species_data, [-3.0, 2.0], [-2.5, 2.5], [-2.0, 4.5])
+
+    @test mg.extent_v_lower == [-3.0, -2.5, -2.0]
+    @test mg.extent_v_upper == [2.0, 2.5, 4.5]
+    @test mg.extent_v_mid == [-0.5, 0.0, 1.25]
+    @test maximum(abs.(mg.Δv .- [1.25, 0.625, 3.25])) < 2*eps()
+
+    compute_props!(particles24, pia, species_data, phys_props)
+    @test pia.n_total[1] < 24
+    @test pia.n_total[1] == phys_props.np[1,1]
+    @test abs(phys_props.n[1,1] - n0_computed) < eps()
+    @test abs(phys_props.T[1,1] - T0_computed) < 1e-14
+    @test abs(v0_computed[1] - phys_props.v[1,1,1]) < 1e-14
+    @test abs(v0_computed[2] - phys_props.v[2,1,1]) < 1e-14
+    @test abs(v0_computed[3] - phys_props.v[3,1,1]) < 1e-14
 end

--- a/test/test_merging_grid_merging.jl
+++ b/test/test_merging_grid_merging.jl
@@ -205,4 +205,30 @@
         @test isnan(particles24[1][i].x[1]) == false
         @test particles24[1][i].w > 0
     end
+
+    gm = GridN2Merge(4, [0.5, 0.7, 0.9])
+    @test gm.Nx == 4
+    @test gm.Ny == 4
+    @test gm.Nz == 4
+    @test maximum(abs.(gm.extent_multiplier .- [0.5, 0.7, 0.9])) < 2 * eps()
+
+    gm = GridN2Merge(6, 1.5)
+    @test gm.Nx == 6
+    @test gm.Ny == 6
+    @test gm.Nz == 6
+    @test maximum(abs.(gm.extent_multiplier .- [1.5, 1.5, 1.5])) < 2 * eps()
+
+    gm = GridN2Merge(4, 6, 2, 3.0, 2.0, 1.0)
+    @test gm.Nx == 4
+    @test gm.Ny == 6
+    @test gm.Nz == 2
+    @test maximum(abs.(gm.extent_multiplier .- [3.0, 2.0, 1.0])) < 2 * eps()
+    # GridN2Merge(N::Int, extent_multiplier::T) where T <: AbstractArray = GridN2Merge(N, N, N, extent_multiplier)
+    # GridN2Merge(N::Int, extent_multiplier::Float64) = GridN2Merge(N, N, N, extent_multiplier)
+    # GridN2Merge(Nx::Int, Ny::Int, Nz::Int,
+    #         extent_multiplier_x::Float64,
+    #         extent_multiplier_y::Float64,
+    #         extent_multiplier_z::Float64) = GridN2Merge(Nx, Ny, Nz, [extent_multiplier_x,
+    #                                                                  extent_multiplier_y,
+    #                                                                  extent_multiplier_z])
 end

--- a/test/test_merging_grid_merging_1D.jl
+++ b/test/test_merging_grid_merging_1D.jl
@@ -133,4 +133,20 @@
 
     @test phys_props.n[1,1] == 8.0
     @test phys_props.n[2,1] == 12.0
+
+    particles, pia = create_particles_in_2cells()
+    # 
+    mg = GridN2Merge(2, 2, 2, 5.5)
+
+    merge_grid_based!(rng, mg, particles[1], pia, 1, 1, species_data, [-16.0, 0.0], [-2.0, 3.0], [4.29, 5.21], grid)
+    merge_grid_based!(rng, mg, particles[1], pia, 2, 1, species_data, [0.0, 17.0], [-2.0, 6.0], [-0.5, 3.5], grid)
+    gridsorter = GridSortInPlace(grid, pia.n_total[1])
+    sort_particles!(gridsorter, grid, particles[1], pia, 1)
+
+    compute_props!(particles, pia, species_data, phys_props)
+    @test phys_props.np[1,1] == 4
+    @test phys_props.np[2,1] == 2
+
+    @test phys_props.n[1,1] == 8.0
+    @test phys_props.n[2,1] == 12.0
 end

--- a/test/test_nnls_ratepreserving_merging.jl
+++ b/test/test_nnls_ratepreserving_merging.jl
@@ -137,8 +137,11 @@
     k_rate_ionization = rate_ionization / w0
 
     # test RHS rate coefficients
-    @test abs(nnls_rp.rhs_vector[8] - k_rate_elastic)/k_rate_elastic < 4*eps()
-    @test abs(nnls_rp.rhs_vector[9] - k_rate_ionization)/k_rate_ionization < 4*eps()
+    scaled_k_elastic = k_rate_elastic / (cs_ref * sqrt(nnls_rp.Ex^2 + nnls_rp.Ey^2 + nnls_rp.Ez^2))
+    scaled_k_ion = k_rate_ionization / (cs_ref * sqrt(nnls_rp.Ex^2 + nnls_rp.Ey^2 + nnls_rp.Ez^2))
+
+    @test abs(nnls_rp.rhs_vector[8] - scaled_k_elastic)/scaled_k_elastic < 4*eps()
+    @test abs(nnls_rp.rhs_vector[9] - scaled_k_ion)/scaled_k_ion < 4*eps()
 
     @test maximum(abs.(nnls.rhs_vector - nnls_rp.rhs_vector[1:7])) < 4*eps()
 
@@ -223,7 +226,10 @@
     k_rate_ionization = rate_ionization / w0
 
     # test RHS rate coefficients
-    @test abs(nnls_rp.rhs_vector[8] - k_rate_elastic)/k_rate_elastic < 4*eps()
+
+    scaled_k_elastic = k_rate_elastic / (cs_ref * sqrt(nnls_rp.Ex^2 + nnls_rp.Ey^2 + nnls_rp.Ez^2))
+
+    @test abs(nnls_rp.rhs_vector[8] - scaled_k_elastic)/scaled_k_elastic < 4*eps()
     @test abs(nnls_rp.rhs_vector[9] - k_rate_ionization) < 4*eps()
 
     @test maximum(abs.(nnls.rhs_vector - nnls_rp.rhs_vector[1:7])) < 4*eps()

--- a/test/test_octree_merging.jl
+++ b/test/test_octree_merging.jl
@@ -43,6 +43,21 @@
         return vp
     end
 
+    function create_2particles_total()
+    # create just 2 particles
+        vp = ParticleVector(2)
+
+        i = 0
+        i += 1
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = create_particle_in_octant(1, 9.0 - 1 - 0.5, w=1)
+        i += 1
+        Merzbild.update_particle_buffer_new_particle!(vp, i)
+        vp[i] = create_particle_in_octant(1, 9.0 - 1 + 0.5, w=2)
+
+        return vp
+    end
+
     particles_data_path = joinpath(@__DIR__, "..", "data", "particles.toml")
     species_data::Vector{Species} = load_species_data(particles_data_path, "Ar")
 
@@ -255,4 +270,45 @@
         @test isnan(particles24[1][i].x[1]) == false
         @test particles24[1][i].w > 0
     end
+
+    particles2 = [create_2particles_total()]
+    pia = ParticleIndexerArray(2)
+
+    pia.indexer[1,1].n_local = 2
+    pia.indexer[1,1].n_group1 = 2
+    pia.indexer[1,1].start1 = 1
+    pia.indexer[1,1].end1 = 2
+
+    pia.indexer[1,1].n_group2 = 0
+    pia.indexer[1,1].start2 = 0
+    pia.indexer[1,1].end2 = -1
+
+    # even the top-level bin cannot be refined
+    merge_octree_N2_based!(rng, octree2, particles2[1], pia, 1, 1, 16)
+    @test octree2.bins[1].np == 2
+    @test octree2.n_particles == 2
+    @test octree2.bins[1].can_be_refined == false
+
+    # non-inheriting bin bounds version
+    particles24 = [create_24_3particles_in_octant()]
+    pia = ParticleIndexerArray(24)
+
+    # symmetric octree with split at v0 = (0.0, 0.0, 0.0)
+    octree = OctreeN2Merge(OctreeBinMidSplit; init_bin_bounds=OctreeInitBinC, bin_bounds_compute=OctreeBinBoundsInherit)
+    merge_octree_N2_based!(rng, octree, particles24[1], pia, 1, 1, 16)
+    compute_props!(particles24, pia, species_data, phys_props)
+
+    n0_computed = phys_props.n[1,1]
+    np0_computed = phys_props.np[1,1]
+    T0_computed = phys_props.T[1,1]
+    v0_computed = phys_props.v[:,1,1]
+
+    compute_props!(particles24, pia, species_data, phys_props)
+
+    @test pia.n_total[1] == phys_props.np[1,1]
+    @test abs(phys_props.n[1,1] - n0_computed) < eps()
+    @test abs(phys_props.T[1,1] - T0_computed) < 1e-14
+    @test abs(v0_computed[1] - phys_props.v[1,1,1]) < 1e-14
+    @test abs(v0_computed[2] - phys_props.v[2,1,1]) < 1e-14
+    @test abs(v0_computed[3] - phys_props.v[3,1,1]) < 1e-14
 end


### PR DESCRIPTION
* Speed-up of variable weight SWPM collisions
* Rate-preserving merging now makes use of reference process cross-sections
* Fix in `simulations/OD/BKW/bkw.jl`
* Clean-up of some `@inbounds` macros in sampling routines
* Option to set merging grid extent explicitly when calling `merge_grid_based!`
* Improved test coverage